### PR TITLE
Markdown component default

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/templates/index.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/templates/index.html
@@ -1,5 +1,5 @@
 @markdown("content", title: "Markdown", default: "## Markdown
 
-Double-click this text to edit the Markdown.
+Right-click on this text and choose *Edit Markdown* from the contextual menu to show the Markdown editor.
 
 Learn more in the [Markdown docs](https://docs.realmacsoftware.com/elements-docs/elements-app/components/built-in-components/markdown).")


### PR DESCRIPTION
Update Markdown component's default text and docs link.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb0ed2da-246b-49f8-aafb-7a129cf2e3bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb0ed2da-246b-49f8-aafb-7a129cf2e3bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

