### PR TITLE
Menu dropdown padding

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.source.js
@@ -52,6 +52,7 @@ const transformHook = (rw) => {
         mobileBackdropColor,
         mobileBackdropOpacity,
         mobileBackdropBlur,
+        desktopSubmenuPadding,
         submenuItemSpacing,
     } = rw.props;
     const { project } = rw;
@@ -183,6 +184,7 @@ const transformHook = (rw) => {
                 mobileMenuBorder,
                 mobileMenuBorderColor,
             ]).toString(),
+            subMenuPadding: classnames([desktopSubmenuPadding]).toString(),
             dropdownItem: classnames([
                 `block px-4`,
                 submenuItemSpacing,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.config.json
@@ -1087,6 +1087,28 @@
                     "divider": {}
                 },
                 {
+                    "title": "Desktop Dropdown",
+                    "heading": {}
+                },
+                {
+                    "title": "Padding",
+                    "id": "desktopSubmenuPadding",
+                    "themeSpacing": {
+                        "mode": "padding",
+                        "default": {
+                            "base": {
+                                "top": "2",
+                                "right": "0",
+                                "bottom": "2",
+                                "left": "0"
+                            }
+                        }
+                    }
+                },
+                {
+                    "divider": {}
+                },
+                {
                     "title": "Item Spacing",
                     "heading": {}
                 },

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/templates/include/desktop_submenu.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/templates/include/desktop_submenu.html
@@ -9,7 +9,7 @@
 >
     <div class="{{classes.desktop.subMenu}}">
         <div
-            class="py-2"
+            class="{{classes.desktop.subMenuPadding}}"
             role="menu"
             aria-orientation="vertical"
             aria-labelledby="options-menu"


### PR DESCRIPTION
Remove hard-coded `py-2` padding from the desktop submenu and add a `desktopSubmenuPadding` property to allow consumers to control it.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f2b34dd-35cd-4290-9c7d-e40d7b937ae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f2b34dd-35cd-4290-9c7d-e40d7b937ae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

