### PR TITLE
Fix missing and incorrect help URLs

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/info.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/info.json
@@ -2,5 +2,6 @@
   "identifier": "com.realmacsoftware.contentSlider",
   "title": "Content Slider",
   "group": "Interactive",
-  "icon": "icon"
+  "icon": "icon",
+  "helpURL": "https://docs.realmacsoftware.com/elements-docs/elements-app/components/built-in-components/content-slider"
 }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.gallery/info.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.gallery/info.json
@@ -2,5 +2,5 @@
   "identifier": "com.realmacsoftware.gallery",
   "title": "Gallery",
   "group": "Media",
-  "helpURL": "https://docs.realmacsoftware.com/elements-docs/elements-app/components/built-in-components/divider"
+  "helpURL": "https://docs.realmacsoftware.com/elements-docs/elements-app/components/built-in-components/gallery"
 }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/info.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/info.json
@@ -2,5 +2,6 @@
     "identifier": "com.realmacsoftware.table",
     "title": "Table",
     "group": "Content",
-    "icon": "icon"
+    "icon": "icon",
+    "helpURL": "https://docs.realmacsoftware.com/elements-docs/elements-app/components/built-in-components/table"
 }


### PR DESCRIPTION
## Summary

- Add missing `helpURL` to **contentSlider** and **table** `info.json` files
- Fix **gallery** `helpURL` which incorrectly pointed to the divider docs page

URLs were inferred from the existing pattern and verified against the gitbook docs repo.

Closes #54

Made with [Cursor](https://cursor.com)