### PR TITLE
Use image captions as alt tags in Image Slider component

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.imageSlider/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.imageSlider/hooks.source.js
@@ -64,6 +64,10 @@ const transformHook = (rw) => {
               ],
           };
 
+    resources?.resources?.forEach((resource) => {
+        resource.alt = resource.caption || "";
+    });
+
     const gridColumns = enablePaginationArrows
         ? "grid-cols-[auto_1fr_auto]"
         : "grid-cols-1";

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.imageSlider/templates/alpine.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.imageSlider/templates/alpine.html
@@ -100,6 +100,7 @@
                         const linkUrl = slide.dataset.link || "";
                         this.originalSlides.push({
                             src: img.src,
+                            alt: img.alt || "",
                             linkUrl: linkUrl || null,
                         });
                     }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.imageSlider/templates/index.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.imageSlider/templates/index.html
@@ -146,7 +146,7 @@
                         >
                             <img
                                 :src="slide.src"
-                                alt="Slide"
+                                :alt="slide.alt"
                                 class="{{classes.slideImage}}"
                                 draggable="false"
                             />
@@ -155,7 +155,7 @@
                     <template x-if="!slide.linkUrl">
                         <img
                             :src="slide.src"
-                            alt="Slide"
+                            :alt="slide.alt"
                             class="{{classes.slideImage}}"
                             draggable="false"
                         />


### PR DESCRIPTION
## Summary

- Derives `alt` text from `resource.caption` in the transform hook, matching the Gallery component's pattern
- Updates Alpine.js `extractSlides()` to capture the `alt` attribute from DOM elements
- Replaces hardcoded `alt="Slide"` with dynamic `:alt="slide.alt"` bindings on carousel images

Fixes #63

## Test plan

- [ ] Add images with captions to an Image Slider component
- [ ] Verify alt attributes on rendered `<img>` elements match the captions
- [ ] Verify images without captions get an empty alt attribute (not "Slide")
- [ ] Test in both slide and fade transition modes

Made with [Cursor](https://cursor.com)