### PR TITLE
Fix Filter component breaking with circumflex accents

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/templates/index.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/templates/index.html
@@ -6,9 +6,9 @@
         q: '',
         init() {
           Alpine.store('filters').registerList(this.groupId);
-        },
-        updateSearch() {
-          Alpine.store('filters').updateQuery(this.groupId, this.q);
+          this.$watch('q', (value) => {
+            Alpine.store('filters').updateQuery(this.groupId, value);
+          });
         }
       }));
   });
@@ -18,7 +18,6 @@
 <input 
     type="search"
     x-model="q"
-    @input="updateSearch()"
     placeholder="{{placeholder}}"
     class="{{classes.input}}"
     aria-label="{{placeholder}}"

--- a/packs/Core.elementsdevpack/components/shared/assets/alpine-store-filters.js
+++ b/packs/Core.elementsdevpack/components/shared/assets/alpine-store-filters.js
@@ -1,4 +1,8 @@
 document.addEventListener('alpine:init', () => {
+    function stripDiacritics(str) {
+        return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    }
+
     Alpine.store('filters', {
         lists: {},
         filteredLists: {},
@@ -81,7 +85,7 @@ document.addEventListener('alpine:init', () => {
         createItem(element) {
             return {
                 element,
-                text: (element.textContent || '').toLowerCase().trim(),
+                text: stripDiacritics((element.textContent || '').toLowerCase().trim()),
                 tags: element.getAttribute('data-filter-tags')?.split(',').map(t => t.trim()) || [],
                 transitionName: element.getAttribute('data-filter-transition') || null,
                 visible: true
@@ -233,7 +237,7 @@ document.addEventListener('alpine:init', () => {
             const { q = '', activeTags = new Set() } = list;
             const tagMatchMode = list.options?.tags?.match || 'any';
             const itemText = (item.text || '').toLowerCase();
-            const searchTerms = q.toLowerCase().trim();
+            const searchTerms = stripDiacritics(q.toLowerCase().trim());
             
             const matchesSearch = !searchTerms || itemText.includes(searchTerms);
             
@@ -241,13 +245,19 @@ document.addEventListener('alpine:init', () => {
             
             if (!Array.isArray(item.tags)) return false;
             
-            const itemTagsLower = item.tags.map(tag => tag?.toLowerCase()).filter(Boolean);
+            const itemTagsLower = item.tags.map(tag => 
+                stripDiacritics(tag?.toLowerCase() || '')
+            ).filter(Boolean);
+            
+            const activeTagsNormalized = new Set(
+                Array.from(activeTags).map(t => stripDiacritics(t))
+            );
             
             const matchesTags = tagMatchMode === 'all'
-                ? Array.from(activeTags).every(activeTag => 
+                ? Array.from(activeTagsNormalized).every(activeTag => 
                     itemTagsLower.includes(activeTag)
                   )
-                : itemTagsLower.some(tag => activeTags.has(tag));
+                : itemTagsLower.some(tag => activeTagsNormalized.has(tag));
             
             return matchesSearch && matchesTags;
         }


### PR DESCRIPTION
## Summary

- **Fixes dead key composition issue**: Replaced `@input="updateSearch()"` with Alpine's `$watch('q', ...)` so the filter no longer desyncs when typing circumflex accents (ê, î, â) via dead keys on macOS
- **Adds accent-insensitive matching**: Search text and item content are now normalized via `String.normalize('NFD')` to strip diacritical marks, so "foret" matches "forêt" and vice versa
- **Tag matching also normalized**: Tag comparisons in the filter store use the same diacritics stripping for consistency

Fixes #52

## Test plan

- [ ] Type circumflex accents (ê, î, â) into the Filter search field on macOS — filter should remain responsive
- [ ] Search "foret" against content containing "forêt" — should match
- [ ] Search "forêt" against content containing "forêt" — should match
- [ ] Search plain ASCII against plain ASCII content — should still work as before
- [ ] Verify tag filtering still works correctly with accented tag names

Made with [Cursor](https://cursor.com)