### PR TITLE
Fix video lightbox close button not clickable on mobile (#70)

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/templates/include/lightbox.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/templates/include/lightbox.html
@@ -50,7 +50,7 @@
     >
         <button
             @click="$dispatch('video-lightbox-close', { id: '{{id}}' })"
-            class="absolute top-0 right-0 p-4 text-white z-10"
+            class="absolute top-0 right-0 p-4 text-white z-20"
         >
             <svg
                 xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## Summary
- Bumps the video lightbox close button from `z-10` to `z-20` so it stacks above the sibling video wrapper (also `z-10`, sized `95vw × 95vh`), which on mobile covers the top-right corner and swallows taps on the X.
- Fixes #70.

## Test plan
- [ ] Preview a project with the video lightbox at mobile width (devtools or device) and confirm the X closes the overlay.
- [ ] Confirm Escape still closes the lightbox and video playback is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)