### PR TITLE
Fix Navbar mobile menu scrolling on iPhone (bottom: auto default)

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.js
@@ -1356,7 +1356,13 @@ const transformHook = (rw) => {
         mobileMenuBorder,
         mobileMenuBorderColor,
         mobileMenuPositionType == "uniform" && mobileMenuInset,
-        mobileMenuPositionType == "individual" && `${mobileMenuPositionTop} ${mobileMenuPositionRight} ${mobileMenuPositionBottom} ${mobileMenuPositionLeft}`
+        mobileMenuPositionType == "individual" && `${mobileMenuPositionTop} ${mobileMenuPositionRight} ${mobileMenuPositionBottom} ${mobileMenuPositionLeft}`,
+        // With bottom at "auto" the fixed panel sizes to its content
+        // and can extend past the viewport, where the body scroll
+        // lock makes items unreachable — clamp the height so
+        // overflow-y-auto engages (3rem ≈ the default top-6 offset
+        // plus matching breathing room below)
+        mobileMenuPositionType == "individual" && mobileMenuPositionBottom.includes("bottom-auto") && `max-h-[calc(100dvh-3rem)]`
       ]).toString()
     }
   };

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.source.js
@@ -257,6 +257,14 @@ const transformHook = (rw) => {
                 mobileMenuPositionType == "uniform" && mobileMenuInset,
                 mobileMenuPositionType == "individual" &&
                     `${mobileMenuPositionTop} ${mobileMenuPositionRight} ${mobileMenuPositionBottom} ${mobileMenuPositionLeft}`,
+                // With bottom at "auto" the fixed panel sizes to its content
+                // and can extend past the viewport, where the body scroll
+                // lock makes items unreachable — clamp the height so
+                // overflow-y-auto engages (3rem ≈ the default top-6 offset
+                // plus matching breathing room below)
+                mobileMenuPositionType == "individual" &&
+                    mobileMenuPositionBottom.includes("bottom-auto") &&
+                    `max-h-[calc(100dvh-3rem)]`,
             ]).toString(),
         },
     };


### PR DESCRIPTION
## Summary

With the Navbar's default individual mobile menu position (`top-6` / `right-6` / `bottom-auto` / `left-6`), the fixed menu panel sizes to its content. When the menu is taller than the viewport, the existing `overflow-y-auto` never engages, and the body scroll lock in `templates/alpine.html` makes items below the fold unreachable on iPhone portrait — users have to rotate to landscape. Reported since June 2025 (forum threads 48241, 56703, 56900; Basecamp todo 10145374433).

## Fix

`hooks.source.js` now adds `max-h-[calc(100dvh-3rem)]` to the mobile menu classes whenever individual positioning leaves `bottom` at `auto`. This clamps the panel to the viewport so `overflow-y-auto` engages and long menus scroll in place. The 3rem allowance mirrors the default `top-6` offset plus matching breathing room below.

Because the clamp is applied in the hook, projects that already store `"auto"` are fixed too. Deliberately unchanged:

- The `properties.config.json` default stays `"auto"` — changing it to a real offset would make every new navbar's menu stretch full-height (with both `top` and `bottom` set, a fixed element fills the space between them), altering the content-sized floating-panel design, and it wouldn't help existing projects.
- Explicit bottom offsets and uniform inset positioning are untouched (the clamp is guarded, so e.g. an `inset-0` full-screen menu isn't shrunk).

`hooks.js` was regenerated with the pack build (`npm run build`); a pristine build was first confirmed to reproduce the committed artifacts byte-for-byte.

## Verification

Headless Chromium at 390×844 (iPhone portrait) with a 20-item menu reproducing the emitted styles:

- **Before:** panel bottom edge 104px below the fold, no internal scroll (`scrollHeight == clientHeight`), last item unreachable.
- **After:** panel clamped inside the viewport, internally scrollable, last item fully visible after scrolling the menu, body scroll lock still active.

`dvh` is supported on iOS 15.4+; older browsers drop the declaration, which is no worse than current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZMsPp5ohdAxednQYEEUeG

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZMsPp5ohdAxednQYEEUeG)_