### PR TITLE
Make the whole Navbar mobile menu row tappable (two-tap bug)

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/templates/include/mobile_item.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/templates/include/mobile_item.html
@@ -1,49 +1,45 @@
-<li x-data="{ open: false }" class="cursor-pointer">
-    <div
-        class="{{classes.mobile.item}} flex items-center justify-between"
-        @click="open = !open"
-        @if(page.isActive)
-        aria-current="page"
-        @endif
-        @if(page.hasActiveChild)
-        data-active-child
-        @endif
-    >
-        @if(page.isFolder)
-        <button
-            aria-expanded="false"
-            x-bind:aria-expanded="open.toString()"
-            class="flex justify-between items-center"
-            @if(page.isActive)
-            aria-current="page"
-            @endif
-        >
-            <span>{{page.title}}</span>
-            @include("mobile_submenu_indicator")
-        </button>
-        @else
+<li x-data="{ open: false }">
+    @if(page.hasPages)
+    <div class="flex items-stretch justify-between">
         <a
-            class="flex justify-between items-center"
+            class="{{classes.mobile.item}} flex flex-1 items-center"
             href="{{page.url}}"
             @if(page.isActive)
             aria-current="page"
+            @endif
+            @if(page.hasActiveChild)
+            data-active-child
             @endif
             @if(page.openInNewWindow)
             target="_blank"
             @endif
             >{{page.title}}</a
         >
-        @if(page.hasPages)
         <button
             @click.stop="open = !open"
             aria-expanded="false"
             x-bind:aria-expanded="open.toString()"
-            class="pl-2"
+            class="flex cursor-pointer items-center pl-2"
         >
             @include("mobile_submenu_indicator")
         </button>
-        @endif @endif
     </div>
+    @else
+    <a
+        class="{{classes.mobile.item}} block"
+        href="{{page.url}}"
+        @if(page.isActive)
+        aria-current="page"
+        @endif
+        @if(page.hasActiveChild)
+        data-active-child
+        @endif
+        @if(page.openInNewWindow)
+        target="_blank"
+        @endif
+        >{{page.title}}</a
+    >
+    @endif
 
     @includeIf(page.hasPages, template: "mobile_submenu")
 </li>

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/templates/include/mobile_submenu.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/templates/include/mobile_submenu.html
@@ -21,28 +21,49 @@
             <span>{{child.title}}</span>
             @include("mobile_submenu_indicator")
         </button>
+        @else @if(child.hasPages)
+        <div class="flex items-stretch justify-between">
+            <a
+                class="{{classes.mobile.item}} flex flex-1 items-center"
+                href="{{child.url}}"
+                @click.stop
+                @if(child.isActive)
+                aria-current="page"
+                @endif
+                @if(child.hasActiveChild)
+                data-active-child
+                @endif
+                @if(child.openInNewWindow)
+                target="_blank"
+                @endif
+                >{{child.title}}</a
+            >
+            <button
+                @click.stop="open = !open"
+                aria-expanded="false"
+                x-bind:aria-expanded="open.toString()"
+                class="flex cursor-pointer items-center pl-2"
+            >
+                @include("mobile_submenu_indicator")
+            </button>
+        </div>
         @else
-        <div
-            class="{{classes.mobile.item}} flex justify-between items-center"
+        <a
+            class="{{classes.mobile.item}} block"
+            href="{{child.url}}"
+            @click.stop
             @if(child.isActive)
             aria-current="page"
             @endif
             @if(child.hasActiveChild)
             data-active-child
             @endif
+            @if(child.openInNewWindow)
+            target="_blank"
+            @endif
+            >{{child.title}}</a
         >
-            <a
-                class="block"
-                href="{{child.url}}"
-                @click.stop
-                @if(child.openInNewWindow)
-                target="_blank"
-                @endif
-                >{{child.title}}</a
-            >
-            @includeIf(child.hasPages, template: "mobile_submenu_indicator")
-        </div>
-        @endif @includeIf(child.hasPages, template: "mobile_submenu_menu")
+        @endif @endif @includeIf(child.hasPages, template: "mobile_submenu_menu")
     </li>
     @endeach
 </ul>


### PR DESCRIPTION
## Summary

Leaf pages in the Navbar mobile menu rendered as a padded, background-styled `<div>` that toggled submenu state on tap (a no-op for pages without children), while the actual link's hit area was limited to the text itself. Tapping the visible row did nothing, so navigation read as needing two taps (forum threads 56937, 56979).

- `templates/include/mobile_item.html` — leaf pages are now a full-row `<a>` carrying `{{classes.mobile.item}}`, so tapping anywhere on the row navigates. Pages that also have children render the styled link with `flex-1` plus a separate chevron `<button @click.stop>` that toggles the submenu without navigating. The unreachable `@if(page.isFolder)` branch was removed (`index.html` routes folders to `mobile_folder.html`, which is unchanged).
- `templates/include/mobile_submenu.html` — second-level leaf rows had the identical defect and get the same treatment. Third-level rows (`mobile_submenu_menu.html`) already put the item classes on the link.
- `aria-current` / `data-active-child` move onto the styled `<a>`, since the `aria-[current=page]:` / `data-[active-child]:` variants generated from `properties.config.json` are self-referential — active highlighting still works, including pages whose only children are hidden from the menu.

Templates only; `hooks.source.js` / `properties.config.json` are untouched, so no generated files needed rebuilding.

## Testing

- All 53 existing tests pass (`node --test test/*.test.mjs`).
- Headless-Chromium preview built from the exact rendered markup of the new templates, using the pack's vendored `alpine.js` + `alpine-collapse.js`: 19/19 hit-area checks passed — row padding navigates at every level, chevrons toggle without navigating and report `aria-expanded`, tapping a child link keeps its parent submenu open, folder rows still toggle across their full width.

Refs Basecamp todo [10145374696](https://3.basecamp.com/6207276/buckets/47199233/todos/10145374696).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017D3UxSNcTvJZn9K7Ffz5Hs

---
_Generated by [Claude Code](https://claude.ai/code/session_017D3UxSNcTvJZn9K7Ffz5Hs)_