### PR TITLE
Add playback time, track durations, compact mode, and pause controls

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.js
@@ -819,6 +819,8 @@ const transformHook = (rw) => {
     trackListMaxHeight,
     trackListPadding,
     trackListGap,
+    trackItemPadding,
+    trackItemGap,
     trackItemBorderRadius,
     trackListArtworkSize,
     trackListArtworkShadow,
@@ -835,6 +837,10 @@ const transformHook = (rw) => {
     trackBgOpacityHover,
     trackDividersColor,
     trackDividersThickness,
+    showTrackDurations,
+    trackDurationColor,
+    trackDurationSize,
+    appearance,
     nowPlayingLayout,
     nowPlayingPadding,
     nowPlayingGap,
@@ -848,6 +854,10 @@ const transformHook = (rw) => {
     nowPlayingProgressBarBgColor,
     nowPlayingProgressBarForegroundColor,
     nowPlayingProgressBarSize,
+    showPlaybackTime,
+    playbackTimeColor,
+    playbackTimeSize,
+    pauseWhenOutOfView,
     initialVolume,
     volumeBarBgColor,
     volumeBarFgColor,
@@ -866,9 +876,13 @@ const transformHook = (rw) => {
     title: "Placeholder Title",
     artist: "Placeholder Artist",
     coverImage: `${sharedAssetPath}/images/image-square.jpg`,
-    audioSource: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3"
+    audioSource: {
+      path: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3"
+    }
   };
   const hasMultipleTracks = (tracks == null ? void 0 : tracks.length) > 1;
+  const isCompact = appearance === "compact";
+  const pauseOutOfView = pauseWhenOutOfView === true || pauseWhenOutOfView === "true";
   const classes = {
     wrapper: classnames([
       "text-white",
@@ -887,25 +901,34 @@ const transformHook = (rw) => {
     nowPlaying: {
       wrapper: classnames([
         `flex items-center flex-wrap`,
-        nowPlayingLayout,
+        isCompact ? "flex-row text-left" : nowPlayingLayout,
         nowPlayingGap,
         nowPlayingPadding
       ]).toString(),
       artwork: classnames([
         "object-cover",
-        nowPlayingArtworkSize,
+        isCompact ? "size-14 shrink-0" : nowPlayingArtworkSize,
         nowPlayingArtworkShadow,
         nowPlayingArtworkBorderRadius
       ]).toString(),
+      content: isCompact ? "flex flex-1 min-w-0 items-center justify-between gap-4" : "",
+      meta: isCompact ? "min-w-0" : "mb-4",
       title: classnames([
         `font-semibold font-body`,
         nowPlayingTitleTextColor,
-        nowPlayingTitleFontSize
+        nowPlayingTitleFontSize,
+        isCompact && "truncate"
       ]).toString(),
       artist: classnames([
         `font-body`,
         nowPlayingArtistTextColor,
-        nowPlayingArtistFontSize
+        nowPlayingArtistFontSize,
+        isCompact && "truncate"
+      ]).toString(),
+      time: classnames([
+        "font-body tabular-nums shrink-0",
+        playbackTimeColor,
+        playbackTimeSize
       ]).toString(),
       progressRow: classnames([
         "flex items-center gap-3 w-full"
@@ -960,7 +983,9 @@ const transformHook = (rw) => {
     ]).toString(),
     track: {
       wrapper: classnames([
-        "group/track flex items-center gap-4 px-4 py-3 cursor-pointer transition",
+        "group/track flex items-center cursor-pointer transition",
+        trackItemGap,
+        trackItemPadding,
         trackItemBorderRadius,
         trackBg,
         trackBgOpacity,
@@ -983,6 +1008,11 @@ const transformHook = (rw) => {
         trackArtistTextColor,
         trackArtistTextColorHover,
         trackListArtistFontSize
+      ]).toString(),
+      duration: classnames([
+        "font-body tabular-nums shrink-0",
+        trackDurationColor,
+        trackDurationSize
       ]).toString()
     },
     icons: {
@@ -993,13 +1023,17 @@ const transformHook = (rw) => {
       play: `${iconPlayPauseColor} ${iconPlayPauseColorHover} ${iconPlayPauseSize} transition`
     }
   };
+  const rootArgs = {
+    "x-data": "elementsAudioPlaylist()",
+    "x-init": "init"
+  };
+  if (pauseOutOfView) {
+    rootArgs["x-bind"] = "pauseWhenHidden";
+  }
   rw.setRootElement({
     as: "div",
     class: classes.wrapper,
-    args: {
-      "x-data": "elementsAudioPlaylist()",
-      "x-init": "init"
-    }
+    args: rootArgs
   });
   rw.setProps({
     id: rw.node.id,
@@ -1008,6 +1042,9 @@ const transformHook = (rw) => {
     firstTrack,
     classes,
     hasMultipleTracks,
+    showPlaybackTime: showPlaybackTime === true || showPlaybackTime === "true",
+    showTrackDurations: showTrackDurations === true || showTrackDurations === "true",
+    pauseWhenOutOfView: pauseOutOfView,
     initialVolume: Math.min(100, Math.max(0, parseFloat(initialVolume != null ? initialVolume : 100) || 0)),
     iconVolume: iconVolume || `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path></svg>`,
     iconMuted: iconMuted || `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"></path></svg>`,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.source.js
@@ -19,6 +19,8 @@ const transformHook = (rw) => {
         trackListMaxHeight,
         trackListPadding,
         trackListGap,
+        trackItemPadding,
+        trackItemGap,
         trackItemBorderRadius,
         trackListArtworkSize,
         trackListArtworkShadow,
@@ -35,6 +37,10 @@ const transformHook = (rw) => {
         trackBgOpacityHover,
         trackDividersColor,
         trackDividersThickness,
+        showTrackDurations,
+        trackDurationColor,
+        trackDurationSize,
+        appearance,
         nowPlayingLayout,
         nowPlayingPadding,
         nowPlayingGap,
@@ -48,6 +54,10 @@ const transformHook = (rw) => {
         nowPlayingProgressBarBgColor,
         nowPlayingProgressBarForegroundColor,
         nowPlayingProgressBarSize,
+        showPlaybackTime,
+        playbackTimeColor,
+        playbackTimeSize,
+        pauseWhenOutOfView,
         initialVolume,
         volumeBarBgColor,
         volumeBarFgColor,
@@ -68,11 +78,16 @@ const transformHook = (rw) => {
         title: "Placeholder Title",
         artist: "Placeholder Artist",
         coverImage: `${sharedAssetPath}/images/image-square.jpg`,
-        audioSource:
-            "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+        audioSource: {
+            path: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
+        },
     };
 
     const hasMultipleTracks = tracks?.length > 1;
+
+    const isCompact = appearance === "compact";
+    const pauseOutOfView =
+        pauseWhenOutOfView === true || pauseWhenOutOfView === "true";
 
     const classes = {
         wrapper: classnames([
@@ -92,25 +107,36 @@ const transformHook = (rw) => {
         nowPlaying: {
             wrapper: classnames([
                 `flex items-center flex-wrap`,
-                nowPlayingLayout,
+                isCompact ? "flex-row text-left" : nowPlayingLayout,
                 nowPlayingGap,
                 nowPlayingPadding,
             ]).toString(),
             artwork: classnames([
                 "object-cover",
-                nowPlayingArtworkSize,
+                isCompact ? "size-14 shrink-0" : nowPlayingArtworkSize,
                 nowPlayingArtworkShadow,
                 nowPlayingArtworkBorderRadius,
             ]).toString(),
+            content: isCompact
+                ? "flex flex-1 min-w-0 items-center justify-between gap-4"
+                : "",
+            meta: isCompact ? "min-w-0" : "mb-4",
             title: classnames([
                 `font-semibold font-body`,
                 nowPlayingTitleTextColor,
                 nowPlayingTitleFontSize,
+                isCompact && "truncate",
             ]).toString(),
             artist: classnames([
                 `font-body`,
                 nowPlayingArtistTextColor,
                 nowPlayingArtistFontSize,
+                isCompact && "truncate",
+            ]).toString(),
+            time: classnames([
+                "font-body tabular-nums shrink-0",
+                playbackTimeColor,
+                playbackTimeSize,
             ]).toString(),
             progressRow: classnames([
                 "flex items-center gap-3 w-full",
@@ -165,7 +191,9 @@ const transformHook = (rw) => {
         ]).toString(),
         track: {
             wrapper: classnames([
-                "group/track flex items-center gap-4 px-4 py-3 cursor-pointer transition",
+                "group/track flex items-center cursor-pointer transition",
+                trackItemGap,
+                trackItemPadding,
                 trackItemBorderRadius,
                 trackBg,
                 trackBgOpacity,
@@ -189,6 +217,11 @@ const transformHook = (rw) => {
                 trackArtistTextColorHover,
                 trackListArtistFontSize,
             ]).toString(),
+            duration: classnames([
+                "font-body tabular-nums shrink-0",
+                trackDurationColor,
+                trackDurationSize,
+            ]).toString(),
         },
         icons: {
             wrapper: `flex items-center justify-center ${iconSpacing}`,
@@ -199,13 +232,19 @@ const transformHook = (rw) => {
         },
     };
 
+    const rootArgs = {
+        "x-data": "elementsAudioPlaylist()",
+        "x-init": "init",
+    };
+
+    if (pauseOutOfView) {
+        rootArgs["x-bind"] = "pauseWhenHidden";
+    }
+
     rw.setRootElement({
         as: "div",
         class: classes.wrapper,
-        args: {
-            "x-data": "elementsAudioPlaylist()",
-            "x-init": "init",
-        },
+        args: rootArgs,
     });
 
     rw.setProps({
@@ -215,6 +254,11 @@ const transformHook = (rw) => {
         firstTrack,
         classes,
         hasMultipleTracks,
+        showPlaybackTime:
+            showPlaybackTime === true || showPlaybackTime === "true",
+        showTrackDurations:
+            showTrackDurations === true || showTrackDurations === "true",
+        pauseWhenOutOfView: pauseOutOfView,
         initialVolume: Math.min(100, Math.max(0, parseFloat(initialVolume ?? 100) || 0)),
         iconVolume: iconVolume || `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"></path></svg>`,
         iconMuted: iconMuted || `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.2.05-.41.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"></path></svg>`,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.config.json
@@ -10,6 +10,21 @@
                     "collection": {
                         "identifier": "com.realmacsoftware.audioPlaylist.collections.tracks"
                     }
+                },
+                {
+                    "divider": {}
+                },
+                {
+                    "title": "Playback",
+                    "heading": {}
+                },
+                {
+                    "title": "Pause When Off Screen",
+                    "property": "pauseWhenOutOfView",
+                    "responsive": false,
+                    "switch": {
+                        "default": false
+                    }
                 }
             ]
         },
@@ -18,6 +33,25 @@
             "icon": "play.square.stack.fill",
             "properties": [
                 {
+                    "title": "Appearance",
+                    "id": "appearance",
+                    "responsive": false,
+                    "select": {
+                        "default": "standard",
+                        "items": [
+                            {
+                                "title": "Standard",
+                                "value": "standard"
+                            },
+                            {
+                                "title": "Compact",
+                                "value": "compact"
+                            }
+                        ]
+                    }
+                },
+                {
+                    "visible": "appearance == 'standard'",
                     "title": "Layout",
                     "id": "nowPlayingLayout",
                     "responsive": false,
@@ -69,6 +103,7 @@
                     "heading": {}
                 },
                 {
+                    "visible": "appearance == 'standard'",
                     "title": "Size",
                     "id": "nowPlayingArtworkSize",
                     "format": "size-{{value}}",
@@ -202,6 +237,43 @@
                             }
                         }
                     }
+                },
+                {
+                    "divider": {}
+                },
+                {
+                    "title": "Time",
+                    "heading": {}
+                },
+                {
+                    "title": "Show Time",
+                    "property": "showPlaybackTime",
+                    "responsive": false,
+                    "switch": {
+                        "default": false
+                    }
+                },
+                {
+                    "enable": "showPlaybackTime == true",
+                    "title": "Color",
+                    "id": "playbackTimeColor",
+                    "format": "text-{{value}}",
+                    "themeColor": {
+                        "default": {
+                            "name": "text",
+                            "brightness": 600
+                        }
+                    }
+                },
+                {
+                    "enable": "showPlaybackTime == true",
+                    "title": "Size",
+                    "id": "playbackTimeSize",
+                    "themeTextStyle": {
+                        "default": {
+                            "base": "sm"
+                        }
+                    }
                 }
             ]
         },
@@ -243,6 +315,41 @@
                         "default": {
                             "base": {
                                 "value": "2"
+                            }
+                        }
+                    }
+                },
+                {
+                    "divider": {}
+                },
+                {
+                    "title": "Rows",
+                    "heading": {}
+                },
+                {
+                    "title": "Padding",
+                    "id": "trackItemPadding",
+                    "themeSpacing": {
+                        "mode": "padding",
+                        "default": {
+                            "base": {
+                                "top": "3",
+                                "right": "4",
+                                "bottom": "3",
+                                "left": "4"
+                            }
+                        }
+                    }
+                },
+                {
+                    "title": "Gap",
+                    "id": "trackItemGap",
+                    "format": "gap-{{value}}",
+                    "themeSpacing": {
+                        "mode": "single",
+                        "default": {
+                            "base": {
+                                "value": "4"
                             }
                         }
                     }
@@ -362,6 +469,43 @@
                             "base": {
                                 "name": "base"
                             }
+                        }
+                    }
+                },
+                {
+                    "divider": {}
+                },
+                {
+                    "title": "Durations",
+                    "heading": {}
+                },
+                {
+                    "title": "Show Durations",
+                    "property": "showTrackDurations",
+                    "responsive": false,
+                    "switch": {
+                        "default": false
+                    }
+                },
+                {
+                    "enable": "showTrackDurations == true",
+                    "title": "Color",
+                    "id": "trackDurationColor",
+                    "format": "text-{{value}}",
+                    "themeColor": {
+                        "default": {
+                            "name": "text",
+                            "brightness": 600
+                        }
+                    }
+                },
+                {
+                    "enable": "showTrackDurations == true",
+                    "title": "Size",
+                    "id": "trackDurationSize",
+                    "themeTextStyle": {
+                        "default": {
+                            "base": "sm"
                         }
                     }
                 },

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
@@ -10,6 +10,21 @@
           "collection": {
             "identifier": "com.realmacsoftware.audioPlaylist.collections.tracks"
           }
+        },
+        {
+          "divider": {}
+        },
+        {
+          "title": "Playback",
+          "heading": {}
+        },
+        {
+          "title": "Pause When Off Screen",
+          "property": "pauseWhenOutOfView",
+          "responsive": false,
+          "switch": {
+            "default": false
+          }
         }
       ]
     },
@@ -18,6 +33,25 @@
       "icon": "play.square.stack.fill",
       "properties": [
         {
+          "title": "Appearance",
+          "id": "appearance",
+          "responsive": false,
+          "select": {
+            "default": "standard",
+            "items": [
+              {
+                "title": "Standard",
+                "value": "standard"
+              },
+              {
+                "title": "Compact",
+                "value": "compact"
+              }
+            ]
+          }
+        },
+        {
+          "visible": "appearance == 'standard'",
           "title": "Layout",
           "id": "nowPlayingLayout",
           "responsive": false,
@@ -69,6 +103,7 @@
           "heading": {}
         },
         {
+          "visible": "appearance == 'standard'",
           "title": "Size",
           "id": "nowPlayingArtworkSize",
           "format": "size-{{value}}",
@@ -205,6 +240,43 @@
               }
             }
           }
+        },
+        {
+          "divider": {}
+        },
+        {
+          "title": "Time",
+          "heading": {}
+        },
+        {
+          "title": "Show Time",
+          "property": "showPlaybackTime",
+          "responsive": false,
+          "switch": {
+            "default": false
+          }
+        },
+        {
+          "enable": "showPlaybackTime == true",
+          "title": "Color",
+          "id": "playbackTimeColor",
+          "format": "text-{{value}}",
+          "themeColor": {
+            "default": {
+              "name": "text",
+              "brightness": 600
+            }
+          }
+        },
+        {
+          "enable": "showPlaybackTime == true",
+          "title": "Size",
+          "id": "playbackTimeSize",
+          "themeTextStyle": {
+            "default": {
+              "base": "sm"
+            }
+          }
         }
       ]
     },
@@ -246,6 +318,41 @@
             "default": {
               "base": {
                 "value": "2"
+              }
+            }
+          }
+        },
+        {
+          "divider": {}
+        },
+        {
+          "title": "Rows",
+          "heading": {}
+        },
+        {
+          "title": "Padding",
+          "id": "trackItemPadding",
+          "themeSpacing": {
+            "mode": "padding",
+            "default": {
+              "base": {
+                "top": "3",
+                "right": "4",
+                "bottom": "3",
+                "left": "4"
+              }
+            }
+          }
+        },
+        {
+          "title": "Gap",
+          "id": "trackItemGap",
+          "format": "gap-{{value}}",
+          "themeSpacing": {
+            "mode": "single",
+            "default": {
+              "base": {
+                "value": "4"
               }
             }
           }
@@ -370,6 +477,43 @@
               "base": {
                 "name": "base"
               }
+            }
+          }
+        },
+        {
+          "divider": {}
+        },
+        {
+          "title": "Durations",
+          "heading": {}
+        },
+        {
+          "title": "Show Durations",
+          "property": "showTrackDurations",
+          "responsive": false,
+          "switch": {
+            "default": false
+          }
+        },
+        {
+          "enable": "showTrackDurations == true",
+          "title": "Color",
+          "id": "trackDurationColor",
+          "format": "text-{{value}}",
+          "themeColor": {
+            "default": {
+              "name": "text",
+              "brightness": 600
+            }
+          }
+        },
+        {
+          "enable": "showTrackDurations == true",
+          "title": "Size",
+          "id": "trackDurationSize",
+          "themeTextStyle": {
+            "default": {
+              "base": "sm"
             }
           }
         },

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/templates/index.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/templates/index.html
@@ -7,7 +7,7 @@
         alt="cover"
     />
     <div class="{{classes.nowPlaying.content}}">
-        <div class="mb-4">
+        <div class="{{classes.nowPlaying.meta}}">
             <h3
                 class="{{classes.nowPlaying.title}}"
                 x-text="currentTrack.title"
@@ -80,6 +80,13 @@
     </div>
 
     <div class="{{classes.nowPlaying.progressRow}}">
+        @if(showPlaybackTime)
+        <span
+            class="{{classes.nowPlaying.time}}"
+            x-text="formatTime(isScrubbing ? scrubTime : currentTime)"
+            >0:00</span
+        >
+        @endif
         <div
             x-ref="progressBar"
             class="{{classes.nowPlaying.progressBar.wrapper}}"
@@ -101,12 +108,18 @@
                 @if(edit)
                 style="display: none"
                 @endif
-                :style="{ left: `calc(${((isScrubbing ? scrubTime : currentTime) / duration) * 100}%) - $el.clientWidth` }"
+                :style="{ left: thumbLeft($el) }"
                 x-show="duration"
             ></div>
         </div>
 
-        @if(enableVolumeControls)
+        @if(showPlaybackTime)
+        <span
+            class="{{classes.nowPlaying.time}}"
+            x-text="duration ? formatTime(duration) : '–:–'"
+            >–:–</span
+        >
+        @endif @if(enableVolumeControls)
         <!-- Volume -->
         <div class="{{classes.nowPlaying.volume.wrapper}}">
             <button
@@ -161,6 +174,14 @@
             <h4 class="{{classes.track.title}}">{{ track.title }}</h4>
             <p class="{{classes.track.artist}}">{{ track.artist }}</p>
         </div>
+        @if(showTrackDurations)
+        <span
+            data-duration
+            class="{{classes.track.duration}}"
+            x-text="trackDurations[{{ track::index }}] != null ? formatTime(trackDurations[{{ track::index }}]) : '–:–'"
+            >–:–</span
+        >
+        @endif
         <div
             x-cloak
             class="[&_svg]:size-4 [&_svg]:{{trackTitleTextColor}}"
@@ -188,6 +209,7 @@
     function elementsAudioPlaylist() {
         return {
             tracks: [],
+            trackDurations: [],
             currentTrackIndex: 0,
             isPlaying: false,
             currentTime: 0,
@@ -202,6 +224,15 @@
 
             get currentTrack() {
                 return this.tracks[this.currentTrackIndex] || {};
+            },
+
+            pauseWhenHidden: {
+                "x-intersect:leave"() {
+                    if (this.isPlaying) {
+                        this.$refs.audio.pause();
+                        this.isPlaying = false;
+                    }
+                },
             },
 
             init() {
@@ -257,6 +288,38 @@
                         }
                     }
                 );
+
+                this.prefetchDurations();
+            },
+
+            prefetchDurations() {
+                // Duration cells only exist in the DOM when "Show
+                // Durations" is on, so their presence gates the prefetch.
+                if (!this.$el.querySelector("[data-duration]")) return;
+                this.trackDurations = this.tracks.map(() => null);
+                this.tracks.forEach((track, index) => {
+                    if (!track.url) return;
+                    let probe = new Audio();
+                    probe.preload = "metadata";
+                    const cleanup = () => {
+                        if (!probe) return;
+                        probe.removeAttribute("src");
+                        probe.load();
+                        probe = null;
+                    };
+                    probe.addEventListener(
+                        "loadedmetadata",
+                        () => {
+                            if (probe && Number.isFinite(probe.duration)) {
+                                this.trackDurations[index] = probe.duration;
+                            }
+                            cleanup();
+                        },
+                        { once: true }
+                    );
+                    probe.addEventListener("error", cleanup, { once: true });
+                    probe.src = track.url;
+                });
             },
 
             togglePlay() {
@@ -416,6 +479,16 @@
                 const mins = Math.floor(seconds / 60) || 0;
                 const secs = Math.floor(seconds % 60) || 0;
                 return `${mins}:${secs < 10 ? "0" : ""}${secs}`;
+            },
+
+            thumbLeft(el) {
+                const progress = this.duration
+                    ? (this.isScrubbing ? this.scrubTime : this.currentTime) /
+                      this.duration
+                    : 0;
+                return `calc(${progress * 100}% - ${
+                    el.clientWidth * progress
+                }px)`;
             },
         };
     }

--- a/test/audio-playlist-component.test.mjs
+++ b/test/audio-playlist-component.test.mjs
@@ -134,3 +134,103 @@ test("root element keeps the alpine bindings", () => {
     assert.equal(rw.root.args["x-data"], "elementsAudioPlaylist()");
     assert.equal(rw.root.args["x-init"], "init");
 });
+
+test("track row uses the density controls instead of hardcoded padding", () => {
+    const wrapper = renderAudioPlaylist({
+        props: {
+            trackItemPadding: "pt-3 pr-4 pb-3 pl-4",
+            trackItemGap: "gap-4",
+        },
+    }).computedProps.classes.track.wrapper;
+
+    assert.match(wrapper, /pt-3/);
+    assert.match(wrapper, /pr-4/);
+    assert.match(wrapper, /pb-3/);
+    assert.match(wrapper, /pl-4/);
+    assert.match(wrapper, /gap-4/);
+
+    const bare = renderAudioPlaylist().computedProps.classes.track.wrapper;
+    assert.match(bare, /group\/track/);
+    assert.match(bare, /cursor-pointer/);
+    assert.doesNotMatch(bare, /px-4/);
+    assert.doesNotMatch(bare, /py-3/);
+});
+
+test("time display classes pick up the configured styling props", () => {
+    const classes = renderAudioPlaylist({
+        props: {
+            playbackTimeColor: "text-text-600",
+            playbackTimeSize: "text-sm",
+            trackDurationColor: "text-text-500",
+            trackDurationSize: "text-xs",
+        },
+    }).computedProps.classes;
+
+    assert.match(classes.nowPlaying.time, /tabular-nums/);
+    assert.match(classes.nowPlaying.time, /text-text-600/);
+    assert.match(classes.nowPlaying.time, /text-sm/);
+    assert.match(classes.track.duration, /tabular-nums/);
+    assert.match(classes.track.duration, /text-text-500/);
+    assert.match(classes.track.duration, /text-xs/);
+});
+
+test("time and pause switches normalize to booleans", () => {
+    const on = renderAudioPlaylist({
+        props: {
+            showPlaybackTime: "true",
+            showTrackDurations: true,
+            pauseWhenOutOfView: "true",
+        },
+    }).computedProps;
+    assert.equal(on.showPlaybackTime, true);
+    assert.equal(on.showTrackDurations, true);
+    assert.equal(on.pauseWhenOutOfView, true);
+
+    const off = renderAudioPlaylist({
+        props: { showPlaybackTime: "false", showTrackDurations: false },
+    }).computedProps;
+    assert.equal(off.showPlaybackTime, false);
+    assert.equal(off.showTrackDurations, false);
+    assert.equal(off.pauseWhenOutOfView, false);
+});
+
+test("pause when off screen wires the intersect binding on the root", () => {
+    const on = renderAudioPlaylist({ props: { pauseWhenOutOfView: true } });
+    assert.equal(on.root.args["x-bind"], "pauseWhenHidden");
+    assert.equal(on.root.args["x-data"], "elementsAudioPlaylist()");
+    assert.equal(on.root.args["x-init"], "init");
+
+    const off = renderAudioPlaylist();
+    assert.ok(!("x-bind" in off.root.args));
+});
+
+test("compact appearance restyles the now playing block", () => {
+    const classes = renderAudioPlaylist({
+        props: {
+            appearance: "compact",
+            nowPlayingLayout: "flex-col text-center",
+            nowPlayingArtworkSize: "size-48",
+        },
+    }).computedProps.classes.nowPlaying;
+
+    assert.match(classes.wrapper, /flex-row/);
+    assert.doesNotMatch(classes.wrapper, /flex-col/);
+    assert.match(classes.artwork, /size-14/);
+    assert.doesNotMatch(classes.artwork, /size-48/);
+    assert.match(classes.content, /justify-between/);
+    assert.equal(classes.meta, "min-w-0");
+    assert.match(classes.title, /truncate/);
+    assert.match(classes.artist, /truncate/);
+});
+
+test("standard appearance keeps today's markup classes", () => {
+    const classes = renderAudioPlaylist({
+        props: { nowPlayingLayout: "flex-col text-center" },
+    }).computedProps.classes.nowPlaying;
+
+    assert.equal(classes.content, "");
+    assert.equal(classes.meta, "mb-4");
+    assert.match(classes.wrapper, /flex-col text-center/);
+    assert.doesNotMatch(classes.title, /truncate/);
+    assert.doesNotMatch(classes.artist, /truncate/);
+});


### PR DESCRIPTION
This PR enhances the audio playlist component with several new features and customization options.

## Summary
Added support for displaying playback time and track durations, introduced a compact appearance mode for the now-playing section, implemented pause-when-off-screen functionality, and made track row spacing configurable.

## Key Changes

- **Playback Time Display**: Added optional display of current playback time and total duration in the progress bar area with configurable color and size styling
- **Track Duration Display**: Added optional display of track durations in the track list with configurable color and size, including metadata prefetching via Audio API
- **Compact Appearance Mode**: Introduced a new "Compact" appearance option that displays the now-playing section in a horizontal layout with smaller artwork and truncated text
- **Pause When Off Screen**: Added a toggle to automatically pause playback when the component scrolls out of view using Intersection Observer
- **Track Row Spacing**: Made track item padding and gap configurable through theme spacing controls instead of hardcoded values
- **Progress Thumb Positioning**: Improved progress bar thumb positioning calculation to account for thumb width

## Implementation Details

- New properties added to configuration: `showPlaybackTime`, `playbackTimeColor`, `playbackTimeSize`, `showTrackDurations`, `trackDurationColor`, `trackDurationSize`, `appearance`, `pauseWhenOutOfView`, `trackItemPadding`, `trackItemGap`
- Track durations are prefetched asynchronously using Audio metadata loading to avoid blocking
- Compact mode conditionally overrides layout, artwork size, and text styling while maintaining all other customizations
- Pause-when-hidden binding is conditionally applied to the root element based on the toggle setting
- Time display uses tabular-nums font feature for consistent digit width
- Comprehensive test coverage added for all new features

https://claude.ai/code/session_01M1Cg8F25awiM3gq78AN4A3