### PR TITLE
Table: auto-detect CSV delimiter for EU locale exports

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/index.php
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/index.php
@@ -136,12 +136,53 @@ COLUMNMETA;
     $csvHeaders = [];
     $csvRows = [];
 
+    // EU-locale Numbers/Excel exports separate fields with semicolons (and
+    // TSVs with tabs), so sniff the delimiter instead of assuming commas.
+    // A candidate wins outright when it splits every sampled row into the
+    // same number of fields (more than one). Semicolon and tab are checked
+    // before comma: a file that consistently splits on them is never a plain
+    // comma CSV, while EU decimal commas ("10,5") can fake a comma split.
+    $tableDetectDelimiter = function ($lines) {
+        $sample = [];
+        foreach ($lines as $line) {
+            if (trim($line) !== '') {
+                $sample[] = $line;
+                if (count($sample) === 10) {
+                    break;
+                }
+            }
+        }
+        $fallback = ',';
+        $fallbackFields = 0;
+        foreach ([';', "\t", ','] as $candidate) {
+            $counts = [];
+            foreach ($sample as $line) {
+                $counts[] = count(str_getcsv($line, $candidate, '"', '\\'));
+            }
+            if (!empty($counts) && $counts[0] > 1 && count(array_unique($counts)) === 1) {
+                return $candidate;
+            }
+            if (array_sum($counts) > $fallbackFields) {
+                $fallbackFields = array_sum($counts);
+                $fallback = $candidate;
+            }
+        }
+        return $fallback;
+    };
+
     if (!$csvError) {
+        // Excel's "CSV UTF-8" export prepends a BOM that would otherwise
+        // leak into the first header cell
+        if (strncmp($csvContent, "\xEF\xBB\xBF", 3) === 0) {
+            $csvContent = substr($csvContent, 3);
+        }
+
         // Parse CSV content
         $allRows = [];
-        $lines = str_getcsv($csvContent, "\n");
+        $lines = preg_split('/\r\n|\r|\n/', $csvContent);
+        $delimiter = $tableDetectDelimiter($lines);
         foreach ($lines as $line) {
-            $parsed = str_getcsv($line);
+            $parsed = str_getcsv($line, $delimiter, '"', '\\');
             if ($parsed !== [null]) {
                 $allRows[] = $parsed;
             }


### PR DESCRIPTION
## Summary

EU-locale Numbers/Excel exports separate CSV fields with semicolons (the comma is the decimal separator there), so files like `Company;Ticker;Weight` collapsed into a single column instead of parsing. Reported on the forums: [Apple's Numbers App to .CSV vs Table](https://forums.realmacsoftware.com/t/57032). Basecamp: [Table: accept semicolon-separated CSVs](https://app.basecamp.com/6207276/buckets/47199233/todos/10145378721).

- **Delimiter sniffing** — samples up to ten non-empty rows and picks the delimiter (`;`, tab, or `,`) that splits every sampled row into the same number of fields. Semicolon/tab are checked before comma because EU decimal commas (`10,5`) can fake a consistent comma split, while a genuine comma CSV never splits consistently on semicolons. Ragged files fall back to the delimiter yielding the most fields, defaulting to comma.
- **Line-ending normalisation** — splits on `/\r\n|\r|\n/` so Windows Excel's CRLF endings don't leak a stray `\r` into the last cell of every row.
- **BOM stripping** — Excel's "CSV UTF-8" export prepends a UTF-8 BOM that otherwise pollutes the first header cell.
- **PHP 8.4** — `str_getcsv`'s enclosure/escape are passed explicitly, silencing the new deprecation notice that could print into published pages.

No new UI option — detection is automatic, and US comma files parse identically to before.

## Testing

- PHP 8.4 harness extracts the detection closure from the shipped template and runs 22 fixtures: the exact forum file, US comma files, TSVs, quoted commas/semicolons, decimal-comma EU data with and without headers, BOM+CRLF files, blank lines, and empty input — all pass.
- `php -l` clean; existing `node --test` suite (20 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcvmJ64WAbtQ3yuv2zn5ot

---
_Generated by [Claude Code](https://claude.ai/code/session_01UcvmJ64WAbtQ3yuv2zn5ot)_