### PR TITLE
Audio: fix scrubber knob detaching from the progress fill

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.js
@@ -947,7 +947,7 @@ const transformHook = (rw) => {
         thumb: classnames([
           nowPlayingProgressBarSize,
           nowPlayingProgressBarForegroundColor,
-          "absolute top-0 aspect-square rounded-full transition duration-[0ms]"
+          "absolute top-0 aspect-square rounded-full"
         ]).toString()
       },
       volume: {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.source.js
@@ -155,7 +155,7 @@ const transformHook = (rw) => {
                 thumb: classnames([
                     nowPlayingProgressBarSize,
                     nowPlayingProgressBarForegroundColor,
-                    "absolute top-0 aspect-square rounded-full transition duration-[0ms]",
+                    "absolute top-0 aspect-square rounded-full",
                 ]).toString(),
             },
             volume: {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/templates/index.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/templates/index.html
@@ -216,7 +216,9 @@
             duration: 0,
             isScrubbing: false,
             scrubTime: 0,
-            _lastTimeUpdate: 0,
+            progressBarHeight: 0,
+            _rafId: null,
+            _barObserver: null,
             volume: 1,
             isMuted: false,
             volumeAdjustable: true,
@@ -270,6 +272,11 @@
                 this.volume = this.volumeAdjustable ? initial : 1;
                 this._lastVolume = this.volume || 1;
 
+                // Cache the track height so the per-frame progress bindings
+                // don't force a layout read on every animation frame. Refs for
+                // child elements aren't registered until after init() runs.
+                this.$nextTick(() => this.watchProgressBarHeight());
+
                 // Ensure only one playlist plays at a time across the page
                 this.$refs.audio.addEventListener("play", () => {
                     window.dispatchEvent(
@@ -277,7 +284,15 @@
                             detail: this.$refs.audio,
                         })
                     );
+                    this.startProgressLoop();
                 });
+
+                // Drive the loop off the audio element's own events rather than
+                // the isPlaying flag, so every pause path — the controls, the
+                // off-screen observer, another playlist taking over — is covered.
+                this.$refs.audio.addEventListener("pause", () =>
+                    this.stopProgressLoop()
+                );
 
                 window.addEventListener(
                     "elementsAudioPlaylist:play",
@@ -290,6 +305,46 @@
                 );
 
                 this.prefetchDurations();
+            },
+
+            destroy() {
+                this.stopProgressLoop();
+                this._barObserver?.disconnect();
+                this._barObserver = null;
+            },
+
+            watchProgressBarHeight() {
+                const bar = this.$refs.progressBar;
+                if (!bar) return;
+                this.progressBarHeight = bar.clientHeight;
+                if (!window.ResizeObserver) return;
+                this._barObserver = new ResizeObserver(() => {
+                    this.progressBarHeight = bar.clientHeight;
+                });
+                this._barObserver.observe(bar);
+            },
+
+            // The browser fires timeupdate only ~4 times a second, which reads
+            // as a visible step. Sample currentTime per frame while playing so
+            // the bar moves smoothly; the loop stops itself once audio pauses.
+            startProgressLoop() {
+                if (this._rafId !== null) return;
+                const step = () => {
+                    const audio = this.$refs.audio;
+                    if (!audio || audio.paused) {
+                        this._rafId = null;
+                        return;
+                    }
+                    if (!this.isScrubbing) this.currentTime = audio.currentTime;
+                    this._rafId = requestAnimationFrame(step);
+                };
+                this._rafId = requestAnimationFrame(step);
+            },
+
+            stopProgressLoop() {
+                if (this._rafId === null) return;
+                cancelAnimationFrame(this._rafId);
+                this._rafId = null;
             },
 
             prefetchDurations() {
@@ -360,13 +415,11 @@
                 this.isPlaying = true;
             },
 
+            // Covers the cases the animation loop doesn't run for: seeking
+            // while paused, and the initial position on load.
             updateTime() {
                 if (!this.isScrubbing) {
-                    const now = Date.now();
-                    if (now - this._lastTimeUpdate > 200) {
-                        this.currentTime = this.$refs.audio.currentTime;
-                        this._lastTimeUpdate = now;
-                    }
+                    this.currentTime = this.$refs.audio.currentTime;
                 }
             },
 
@@ -492,9 +545,14 @@
             // The thumb is aspect-square and sized to the track height, so the
             // track's own height is the thumb's width. Measure the wrapper, not
             // the thumb — the thumb is x-show hidden until duration loads and
-            // would measure 0.
+            // would measure 0. Prefer the observed height so the animation loop
+            // doesn't force a layout read every frame.
             thumbSize() {
-                return this.$refs.progressBar?.clientHeight || 0;
+                return (
+                    this.progressBarHeight ||
+                    this.$refs.progressBar?.clientHeight ||
+                    0
+                );
             },
 
             // Extend the fill to the thumb's centre so the two meet seamlessly.

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/templates/index.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/templates/index.html
@@ -99,7 +99,7 @@
                 @if(edit)
                 style="width: calc(50%)"
                 @endif
-                :style="{ width: ((isScrubbing ? scrubTime : currentTime) / duration * 100) + '%' }"
+                :style="{ width: progressFillWidth() }"
             ></div>
 
             <!-- Draggable thumb -->
@@ -108,7 +108,7 @@
                 @if(edit)
                 style="display: none"
                 @endif
-                :style="{ left: thumbLeft($el) }"
+                :style="{ left: thumbLeft() }"
                 x-show="duration"
             ></div>
         </div>
@@ -481,13 +481,37 @@
                 return `${mins}:${secs < 10 ? "0" : ""}${secs}`;
             },
 
-            thumbLeft(el) {
-                const progress = this.duration
-                    ? (this.isScrubbing ? this.scrubTime : this.currentTime) /
-                      this.duration
-                    : 0;
+            progressRatio() {
+                if (!this.duration) return 0;
+                const time = this.isScrubbing
+                    ? this.scrubTime
+                    : this.currentTime;
+                return Math.min(Math.max(time / this.duration, 0), 1);
+            },
+
+            // The thumb is aspect-square and sized to the track height, so the
+            // track's own height is the thumb's width. Measure the wrapper, not
+            // the thumb — the thumb is x-show hidden until duration loads and
+            // would measure 0.
+            thumbSize() {
+                return this.$refs.progressBar?.clientHeight || 0;
+            },
+
+            // Extend the fill to the thumb's centre so the two meet seamlessly.
+            progressFillWidth() {
+                if (!this.duration) return "0%";
+                const progress = this.progressRatio();
+                return `calc(${progress * 100}% + ${
+                    (0.5 - progress) * this.thumbSize()
+                }px)`;
+            },
+
+            // Inset travel: left edge at 0 when progress is 0, right edge flush
+            // with the track when progress is 1.
+            thumbLeft() {
+                const progress = this.progressRatio();
                 return `calc(${progress * 100}% - ${
-                    el.clientWidth * progress
+                    progress * this.thumbSize()
                 }px)`;
             },
         };


### PR DESCRIPTION
## What

The Audio component's progress bar rendered its circular scrubber knob floating to the right of where the progress actually ended, instead of sitting on the playhead.


## Why

The fill and the knob were using two different coordinate conventions:

- **Fill width** was the raw ratio: `P%`.
- **Knob `left`** (`thumbLeft()`) used native `<input type=range>` "inset" travel: `calc(P% - knobWidth × P)`. That formula positions the knob's *left edge*, so the knob travels from `0` to `100% - knobWidth` and never overhangs the track ends — but it is only visually correct if the fill extends to the knob's *centre*.

Because the fill stopped at the raw `P%`, the knob's left edge landed (almost) exactly where the fill ended, so the entire knob body stuck out to the right. The knob is the same height and colour as the fill, so the intended design was clearly a seamless rounded cap — the inset travel was right, the fill was what was wrong.

The artifact scales with track height: nearly invisible at the `1.5` (6px) default, glaring once "Progress Bar → Size" is increased.

A second, related defect: `thumbLeft(el)` measured `el.clientWidth` on the knob itself, but the knob carries `x-show="duration"` and `duration` starts at `0` — so the first evaluation measured a `display:none` element and got `0`, leaving the position uncompensated until the next `timeupdate`.

## How

- Factored out a shared `progressRatio()` so the fill and the knob are computed from the same clamped number.
- Extended the fill to the knob's centre: `calc(P% + (0.5 - P) × knobSize)`.
- Left the knob's inset travel unchanged — it was already correct.
- Switched the size measurement to the **wrapper's** `clientHeight` instead of the knob's `clientWidth`. The knob is `aspect-square` sized to the track height, so the wrapper's height *is* the knob's width, and the wrapper is always rendered.

## Verification

Ran the actual code in a browser harness replicating the markup at a 32px track height, measuring the fill's right edge against the knob's centre:

| progress | fill-right − knob-centre (after) | (before) |
|---|---|---|
| 0% | 0 | −16 |
| 8% | 0 | −13.4 |
| 25% | 0 | −8 |
| 50% | 0 | 0 |
| 75% | 0 | +8 |
| 100% | 0 | +16 |

The ±16px before is half a knob width — the detached circle. After, the gap is exactly 0 at every position, including while scrubbing. Also confirmed:

- Knob overhang is **0px** at both extremes, so `overflow-hidden` on the wrapper is still safe.
- `duration = 0` (before metadata loads) renders zero fill with no stray half-knob dot.
- `currentTime > duration` clamps to the track end.

## Notes for reviewers

- **Template-only change** — no `hooks.source.js` or `properties.config.json` edits, so no `npm run build` and no regenerated `properties.json` / `hooks.js` in this diff.
- The knob is hidden in the edit canvas (`display: none` under `@if(edit)`), so this needs **Preview** or a published page to see. The edit-mode static `width: calc(50%)` is still exactly correct — at `p = 0.5` the new compensation term is zero.
- Worth a sanity check in a real Preview with an actual track before merge; my verification was a faithful harness, not the app itself.

Two pre-existing issues I deliberately left alone:

- `updateTime()` throttles to 200ms, so the bar steps at ~5fps. Now that the knob is welded to the fill, that choppiness is the most visible remaining thing about the bar.
- The knob's `transition duration-[0ms]` class in `hooks.source.js` is a no-op — Tailwind's `transition` doesn't cover `left`, and the duration is zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Follow-up: the two issues flagged above are now fixed too

### Progress motion (`timeupdate` ~4Hz stepping)

The bar was driven solely by `timeupdate`, which browsers fire only ~4 times a second — so the knob stepped rather than moved. The 200ms throttle in `updateTime()` was almost a no-op on top of that; the cadence was the *event*, not the throttle.

Now `currentTime` is sampled on an animation frame while playing. Measured against the real component script:

| | distinct positions per second |
|---|---|
| `timeupdate` only (before) | 5 |
| animation loop (after) | one per frame callback (~60/s at a typical refresh rate) |

The loop is driven off the audio element's own `play`/`pause` events rather than the `isPlaying` flag, so **every** pause path is covered — the controls, the off-screen intersection observer, and another playlist taking over. It also self-terminates if it ever sees `audio.paused`, guards against double-starting, and leaves `currentTime` alone while scrubbing. `requestAnimationFrame` idles in background tabs, so it costs nothing when the page isn't visible.

`timeupdate` is kept, now unthrottled, to cover what the loop doesn't run for: seeking while paused, and the initial position on load.

**One consequence worth reviewing:** the loop dirties layout every frame, so `thumbSize()` reading `clientHeight` per binding evaluation would have forced a synchronous layout ~120 times a second. The track height is now cached and kept fresh with a `ResizeObserver` (with a live read as fallback). That also fixes a latent staleness bug — the geometry previously only re-measured when the time changed, so resizing the container left the knob mispositioned until the next `timeupdate`.

### Dead transition classes

`transition duration-[0ms]` on the knob never did anything — Tailwind's `transition` utility doesn't cover `left`, and the duration was zero. Removed. With per-frame updates a CSS transition on the knob would only add lag.

This one touches `hooks.source.js`, so `hooks.js` is regenerated via `npm run build` and is included in the diff. The build is deterministic — it rewrote every component but only the audio playlist's output actually changed.

### Verification

Against the **real** component script extracted verbatim from the template:

- Geometry still welds exactly — fill-right minus knob-centre is `0.00px` at 0/8/25/50/75/100%, knob overhang 0px at both extremes.
- `play` event starts the loop; `pause` event stops it; loop self-terminates when it sees `audio.paused`; double-start doesn't spawn a second loop; scrubbing isn't clobbered; `destroy()` cancels both the loop and the observer.
- `duration = 0` still renders zero fill with the knob hidden.

**Not directly observed:** neither available browser surface reported a visible document (`document.visibilityState` was `hidden` in both), and `requestAnimationFrame` and `ResizeObserver` callbacks don't fire in a hidden document. Frame cadence was therefore exercised with a scheduler shim, and `ResizeObserver` was confirmed only as far as being correctly constructed and observing the right element with the right initial value. Real frame cadence and observer-delivery-on-resize rest on standard platform behaviour rather than something I watched happen — worth a quick look in a real Preview when reviewing.
