### PR TITLE
Container: fix background overlay gradient rendering opaque in light mode

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/hooks.js
@@ -717,28 +717,34 @@ const globalOverlayGradient = (app, prefix) => {
   );
   const classes = classnames([
     directionClass,
-    `${fromColor}/${fromOpacity}`,
+    fromColor,
+    fromOpacity,
     fromPosition,
-    `${toColor}/${toOpacity}`,
+    toColor,
+    toOpacity,
     toPosition
   ]);
   if (viaEnabled == "true") {
     classes.add([
-      `${viaColor}/${viaOpacity}`,
+      viaColor,
+      viaOpacity,
       viaPosition
     ]);
   }
   if (controlType == "hover") {
     classes.add([
       `${prefix}:${directionEndClass}`,
-      `${prefix}:${fromColorEnd}/${fromOpacityEnd}`,
+      injectPrefixOnDarkModeColors(prefix, `${prefix}:${fromColorEnd}`),
+      `${prefix}:${fromOpacityEnd}`,
       `${prefix}:${fromPositionEnd}`,
-      `${prefix}:${toColorEnd}/${toOpacityEnd}`,
+      injectPrefixOnDarkModeColors(prefix, `${prefix}:${toColorEnd}`),
+      `${prefix}:${toOpacityEnd}`,
       `${prefix}:${toPositionEnd}`
     ]);
     if (viaEnabledEnd == "true") {
       classes.add([
-        `${prefix}:${viaColorEnd}/${viaOpacityEnd}`,
+        injectPrefixOnDarkModeColors(prefix, `${prefix}:${viaColorEnd}`),
+        `${prefix}:${viaOpacityEnd}`,
         `${prefix}:${viaPositionEnd}`
       ]);
     }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -4691,7 +4691,7 @@
           },
           "title": "Color",
           "id": "globalOverlayGradientFromColor",
-          "format": "from-{{value}}",
+          "format": "from-{{value}}/(--overlayGradientFromOpacity)",
           "themeColor": {
             "default": {
               "name": "brand",
@@ -4708,7 +4708,7 @@
           },
           "title": "Opacity",
           "id": "globalOverlayGradientFromOpacity",
-          "format": "[{{value}}%]",
+          "format": "[--overlayGradientFromOpacity:{{value}}%]",
           "responsive": false,
           "slider": {
             "default": 100,
@@ -4770,7 +4770,7 @@
           },
           "title": "Color",
           "id": "globalOverlayGradientViaColor",
-          "format": "via-{{value}}",
+          "format": "via-{{value}}/(--overlayGradientViaOpacity)",
           "themeColor": {
             "default": {
               "name": "brand",
@@ -4787,7 +4787,7 @@
           },
           "title": "Opacity",
           "id": "globalOverlayGradientViaOpacity",
-          "format": "[{{value}}%]",
+          "format": "[--overlayGradientViaOpacity:{{value}}%]",
           "responsive": false,
           "slider": {
             "default": 100,
@@ -4836,7 +4836,7 @@
           },
           "title": "Color",
           "id": "globalOverlayGradientToColor",
-          "format": "to-{{value}}",
+          "format": "to-{{value}}/(--overlayGradientToOpacity)",
           "themeColor": {
             "default": {
               "name": "brand",
@@ -4853,7 +4853,7 @@
           },
           "title": "Opacity",
           "id": "globalOverlayGradientToOpacity",
-          "format": "[{{value}}%]",
+          "format": "[--overlayGradientToOpacity:{{value}}%]",
           "responsive": false,
           "slider": {
             "default": 100,
@@ -5135,7 +5135,7 @@
           },
           "title": "Color",
           "id": "globalOverlayGradientFromColorEnd",
-          "format": "from-{{value}}",
+          "format": "from-{{value}}/(--overlayGradientFromOpacityEnd)",
           "themeColor": {
             "default": {
               "name": "brand",
@@ -5152,7 +5152,7 @@
           },
           "title": "Opacity",
           "id": "globalOverlayGradientFromOpacityEnd",
-          "format": "[{{value}}%]",
+          "format": "[--overlayGradientFromOpacityEnd:{{value}}%]",
           "responsive": false,
           "slider": {
             "default": 100,
@@ -5214,7 +5214,7 @@
           },
           "title": "Color",
           "id": "globalOverlayGradientViaColorEnd",
-          "format": "via-{{value}}",
+          "format": "via-{{value}}/(--overlayGradientViaOpacityEnd)",
           "themeColor": {
             "default": {
               "name": "brand",
@@ -5231,7 +5231,7 @@
           },
           "title": "Opacity",
           "id": "globalOverlayGradientViaOpacityEnd",
-          "format": "[{{value}}%]",
+          "format": "[--overlayGradientViaOpacityEnd:{{value}}%]",
           "responsive": false,
           "slider": {
             "default": 100,
@@ -5280,7 +5280,7 @@
           },
           "title": "Color",
           "id": "globalOverlayGradientToColorEnd",
-          "format": "to-{{value}}",
+          "format": "to-{{value}}/(--overlayGradientToOpacityEnd)",
           "themeColor": {
             "default": {
               "name": "brand",
@@ -5297,7 +5297,7 @@
           },
           "title": "Opacity",
           "id": "globalOverlayGradientToOpacityEnd",
-          "format": "[{{value}}%]",
+          "format": "[--overlayGradientToOpacityEnd:{{value}}%]",
           "responsive": false,
           "slider": {
             "default": 100,


### PR DESCRIPTION
## Summary

Fixes the bug reported in [forum 57186](https://forums.realmacsoftware.com/t/something-is-wrong-with-container-background-overlays/57186): a Container background overlay gradient with reduced stop opacity looked correct in dark mode but rendered fully opaque in light mode, completely hiding the background image.

Theme colours with separate light/dark values expand to compound classes (`from-A dark:from-B`); the overlay gradient appended the opacity modifier to that string, so it only attached to the `dark:` variant and light mode got the stop at 100% opacity.

## Changes

Build artifacts only — `hooks.js` and `properties.json` for `com.realmacsoftware.container`, regenerated via `npm run build` from the source fix in realmacsoftware/RWElementsPacksTools#12:

- Stop colour formats now use the CSS-variable opacity shorthand (`from-{{value}}/(--overlayGradientFromOpacity)` + `[--overlayGradientFromOpacity:{{value}}%]`), applied to every colour variant.
- `globalOverlayGradient` emits colour and opacity as separate classes, and hover-end colours keep their `dark:` variants correctly prefixed.

No other component bundles the overlay gradient, so nothing else changed. Existing documents need no migration — stored values re-expand through the new formats.

**Depends on** realmacsoftware/RWElementsPacksTools#12 (merge that first, or rebuilds will regress this).

## Testing

- rw-elements-tools suite: 76/76 passing, including two new regression tests for this exact bug.
- Verified the regenerated diff touches only the overlay gradient formats and class assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)