### PR TITLE
Image: fix audit findings from the code-review report

### DIFF
--- a/packs/Core.elementsdevpack/components/com.elementsplatform.mask/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.mask/hooks.js
@@ -221,7 +221,7 @@ const maskClasses = (rw) => {
   switch (maskType) {
     case "svg": {
       if (!(maskResource == null ? void 0 : maskResource.image)) return ["mask-none"];
-      const encodedSvg = encodeURIComponent(maskResource.image);
+      const encodedSvg = encodeURIComponent(maskResource.image).replace(/'/g, "%27").replace(/\(/g, "%28").replace(/\)/g, "%29");
       return [
         `mask-[url('data:image/svg+xml,${encodedSvg}')]`,
         maskMode,

--- a/packs/Core.elementsdevpack/components/com.elementsplatform.mask/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.mask/hooks.source.js
@@ -39,7 +39,11 @@ const maskClasses = (rw) => {
         case "svg": {
             if (!maskResource?.image) return ["mask-none"];
 
-            const encodedSvg = encodeURIComponent(maskResource.image);
+            // encodeURIComponent leaves ' ( ) raw; an unencoded ' terminates the surrounding url('…')
+            const encodedSvg = encodeURIComponent(maskResource.image)
+                .replace(/'/g, "%27")
+                .replace(/\(/g, "%28")
+                .replace(/\)/g, "%29");
             return [
                 `mask-[url('data:image/svg+xml,${encodedSvg}')]`,
                 maskMode,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/assets/page/image-lightbox.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/assets/page/image-lightbox.js
@@ -6,6 +6,7 @@ document.addEventListener("alpine:init", () => {
         srcDark: null,
         alt: "",
         init() {
+            this.listenerController = new AbortController();
             const handlers = {
                 keydown: (e) => e.key === "Escape" && (this.open = false),
                 "image-lightbox-toggle": () => (this.open = !this.open),
@@ -25,9 +26,13 @@ document.addEventListener("alpine:init", () => {
                         if (event === "keydown" || e.detail.id === this.id) {
                             handler(e);
                         }
-                    }
+                    },
+                    { signal: this.listenerController.signal }
                 );
             });
+        },
+        destroy() {
+            this.listenerController.abort();
         },
     }));
 });

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
@@ -628,7 +628,7 @@ const transformHook = (rw) => {
   const maskClasses = [];
   if (wantsMask) {
     const svgContent = imageMaskResource.image;
-    const encodedSvg = encodeURIComponent(svgContent);
+    const encodedSvg = encodeURIComponent(svgContent).replace(/'/g, "%27").replace(/\(/g, "%28").replace(/\)/g, "%29");
     const maskUrl = `url('data:image/svg+xml,${encodedSvg}')`;
     const maskSize = `${imageMaskSize}`.trim().replace(/\s+/g, "_");
     maskClasses.push(

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
@@ -631,11 +631,12 @@ const transformHook = (rw) => {
     const svgContent = imageMaskResource.image;
     const encodedSvg = encodeURIComponent(svgContent);
     const maskUrl = `url('data:image/svg+xml,${encodedSvg}')`;
+    const maskSize = `${imageMaskSize}`.trim().replace(/\s+/g, "_");
     maskClasses.push(
       `[-webkit-mask-image:${maskUrl}]`,
       `[mask-image:${maskUrl}]`,
-      `[-webkit-mask-size:${imageMaskSize}]`,
-      `[mask-size:${imageMaskSize}]`,
+      `[-webkit-mask-size:${maskSize}]`,
+      `[mask-size:${maskSize}]`,
       `[-webkit-mask-repeat:no-repeat]`,
       `[mask-repeat:no-repeat]`,
       `[-webkit-mask-position:center]`,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
@@ -537,7 +537,6 @@ const transformHook = (rw) => {
   const wantsFetchPriority = imageFetchPriority != "auto";
   const isEditMode = mode == "edit";
   const isCMSImage = imageType == "cms";
-  const isCustomImage = imageType == "custom";
   const isResourceImage = imageType == "resource";
   const wantsLightboxAtAnyBreakpoint = Object.values(wantsLightbox).some((v) => v === true);
   const lightboxCursorClasses = Object.entries(wantsLightbox).map(([breakpoint, enabled]) => {
@@ -690,15 +689,12 @@ const transformHook = (rw) => {
   }
   rw.setProps({
     isCMSImage,
-    isCustomImage,
     isResourceImage,
-    isEditMode,
     lightImage,
     hasDarkImage: ((_a = darkImage.resource) == null ? void 0 : _a.image) || false,
     darkImage,
     hasImage: ((_b = lightImage.resource) == null ? void 0 : _b.image) || false,
     imageProtection,
-    defaultSrc: image,
     alt: isResourceImage ? (image == null ? void 0 : image.alt) || (imageDark == null ? void 0 : imageDark.alt) : imageAlt,
     classes,
     imageWidth: !isResourceImage ? imageIntrinsicWidth : (_c = lightImage.resource) == null ? void 0 : _c.width,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
@@ -654,7 +654,7 @@ const transformHook = (rw) => {
       "block"
     ]).toString(),
     img: classnames([
-      wantsLightboxAtAnyBreakpoint && lightboxCursorClasses,
+      wantsLightboxAtAnyBreakpoint && !isEditMode && lightboxCursorClasses,
       `max-w-[100%] w-full`,
       globalTransitions(rw),
       globalEffects(rw),

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
@@ -664,7 +664,7 @@ const transformHook = (rw) => {
       globalBorders(rw),
       // displaySize(),
       objectClasses(rw),
-      rw.props.aspectRatio == "aspect-[auto]" ? `aspect-[${image == null ? void 0 : image.aspect}]` : aspectRatioClasses(rw),
+      rw.props.aspectRatio == "aspect-[auto]" ? isResourceImage && (image == null ? void 0 : image.aspect) ? `aspect-[${image.aspect}]` : null : aspectRatioClasses(rw),
       ...maskClasses
     ]).toString(),
     lightbox: {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
@@ -210,7 +210,7 @@ const transformHook = (rw) => {
             // displaySize(),
             objectClasses(rw),
             rw.props.aspectRatio == "aspect-[auto]"
-                ? `aspect-[${image?.aspect}]`
+                ? (isResourceImage && image?.aspect ? `aspect-[${image.aspect}]` : null)
                 : aspectRatioClasses(rw),
             ...maskClasses,
         ]).toString(),

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
@@ -203,7 +203,7 @@ const transformHook = (rw) => {
             'block',
         ]).toString(),
         img: classnames([
-            wantsLightboxAtAnyBreakpoint && lightboxCursorClasses,
+            wantsLightboxAtAnyBreakpoint && !isEditMode && lightboxCursorClasses,
             `max-w-[100%] w-full`,
             globalTransitions(rw),
             globalEffects(rw),

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
@@ -170,7 +170,11 @@ const transformHook = (rw) => {
     const maskClasses = [];
     if (wantsMask) {
         const svgContent = imageMaskResource.image;
-        const encodedSvg = encodeURIComponent(svgContent);
+        // encodeURIComponent leaves ' ( ) raw; an unencoded ' terminates the surrounding url('…')
+        const encodedSvg = encodeURIComponent(svgContent)
+            .replace(/'/g, "%27")
+            .replace(/\(/g, "%28")
+            .replace(/\)/g, "%29");
         const maskUrl = `url('data:image/svg+xml,${encodedSvg}')`;
         // Arbitrary-value classes must be a single token: "100% 100%" (Fill) -> "100%_100%"
         const maskSize = `${imageMaskSize}`.trim().replace(/\s+/g, "_");

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
@@ -37,7 +37,6 @@ const transformHook = (rw) => {
     const wantsFetchPriority = imageFetchPriority != "auto";
     const isEditMode = mode == "edit";
     const isCMSImage = imageType == "cms";
-    const isCustomImage = imageType == "custom";
     const isResourceImage = imageType == "resource";
 
     const wantsLightboxAtAnyBreakpoint = Object.values(wantsLightbox).some(v => v === true);
@@ -240,15 +239,12 @@ const transformHook = (rw) => {
 
     rw.setProps({
         isCMSImage,
-        isCustomImage,
         isResourceImage,
-        isEditMode,
         lightImage,
         hasDarkImage: darkImage.resource?.image || false,
         darkImage,
         hasImage: lightImage.resource?.image || false,
         imageProtection,
-        defaultSrc: image,
         alt: isResourceImage ? (image?.alt || imageDark?.alt) : imageAlt,
         classes,
         imageWidth: !isResourceImage ? imageIntrinsicWidth : lightImage.resource?.width,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.source.js
@@ -173,12 +173,14 @@ const transformHook = (rw) => {
         const svgContent = imageMaskResource.image;
         const encodedSvg = encodeURIComponent(svgContent);
         const maskUrl = `url('data:image/svg+xml,${encodedSvg}')`;
+        // Arbitrary-value classes must be a single token: "100% 100%" (Fill) -> "100%_100%"
+        const maskSize = `${imageMaskSize}`.trim().replace(/\s+/g, "_");
 
         maskClasses.push(
             `[-webkit-mask-image:${maskUrl}]`,
             `[mask-image:${maskUrl}]`,
-            `[-webkit-mask-size:${imageMaskSize}]`,
-            `[mask-size:${imageMaskSize}]`,
+            `[-webkit-mask-size:${maskSize}]`,
+            `[mask-size:${maskSize}]`,
             `[-webkit-mask-repeat:no-repeat]`,
             `[mask-repeat:no-repeat]`,
             `[-webkit-mask-position:center]`,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.config.json
@@ -47,7 +47,7 @@
                     "id": "imageSizingType",
                     "responsive": false,
                     "segmented": {
-                        "default": "devices",
+                        "default": "none",
                         "items": [
                             {
                                 "title": "Original",

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
@@ -179,7 +179,7 @@
           "id": "imageSizingType",
           "responsive": false,
           "segmented": {
-            "default": "devices",
+            "default": "none",
             "items": [
               {
                 "title": "Original",

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/templates/include/lightbox.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/templates/include/lightbox.html
@@ -44,7 +44,7 @@
                     <source :srcset="srcDark" media="(prefers-color-scheme: dark)" />
                 </template>
                 <img
-                    class="{{classes.lightboxImg}} w-full h-full object-contain object-center"
+                    class="w-full h-full object-contain object-center"
                     :src="src"
                     :alt="alt"
                     @if(imageProtection)

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/templates/include/lightbox.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/templates/include/lightbox.html
@@ -4,7 +4,7 @@
 
 @portal(bodyEnd)
 <div x-cloak x-data="imageLightbox('{{id}}')">
-    <div x-show="open" class="fixed inset-0 z-50 grid place-items-center">
+    <div x-show="open" x-transition:leave="duration-200" class="fixed inset-0 z-50 grid place-items-center">
         <div
             @click="$dispatch('image-lightbox-close', { id: '{{id}}' })"
             class="{{classes.lightbox.overlay}}"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/templates/index.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/templates/index.html
@@ -68,6 +68,7 @@
                 let enabled = false;
                 bps.forEach(bp => { if (window.innerWidth >= bp.minWidth) enabled = bp.enabled; });
                 if (!enabled) return;
+                $event.preventDefault();
                 const pic = $el.closest('picture');
                 const light = pic && pic.querySelector('source[data-lightbox-role=&quot;light&quot;]');
                 const dark = pic && pic.querySelector('source[data-lightbox-role=&quot;dark&quot;]');


### PR DESCRIPTION
Fixes nine verified findings from the Image component code-review audit (`RWAI/audit/code-review/Core/Image-issues.md`, verdicts in `RWAI/audit/verify-and-tune/code-review/Image-issues-verification.md`). One commit per finding.

## Bugs

- **Mask "Fill" size split the class attribute** — the `100% 100%` value was interpolated verbatim into the arbitrary-value classes, producing two broken tokens. Now normalised to `100%_100%` (same idiom as the Mask component's `arbitraryValue`).
- **Link + lightbox both fired on the same click** — with a Link set, a lightbox-enabled click also navigated the wrapping `<a>`. The click handler now calls `$event.preventDefault()` after the breakpoint check, so links still work at breakpoints where the lightbox is off.
- **`aspect-[undefined]` from Auto aspect ratio** — the resource aspect is now only used when the image is a resource and the aspect exists; otherwise nothing is emitted (native auto behaviour). Also stops a stale resource aspect leaking onto custom/CMS images.
- **SVG mask data URIs broke on single-quoted SVGs** (Image + Mask) — `encodeURIComponent` leaves `' ( )` raw, so a single-quoted SVG terminated the `url('…')` early and the mask silently failed. Both encode sites now also encode `%27`/`%28`/`%29`.
- **Lightbox close animations never played** — the untransitioned parent hid the subtree instantly on close. It now holds for the children's 200ms leave duration so the fade-out renders.

## Inconsistencies / cleanup

- **`imageSizingType` default was not a valid segment value** (`devices` vs `none`/`custom`) — default changed to `none`; behaviour is unchanged since the hook treated any non-custom value as Original.
- **Unconsumed hook outputs** — dropped `defaultSrc`, `isCustomImage`, `isEditMode` from `setProps` and the producer-less `{{classes.lightboxImg}}` reference in the lightbox template.
- **Lightbox listeners were never removed** — now registered against an `AbortController` aborted in Alpine's `destroy()`.
- **Edit mode showed a zoom-in cursor for a disabled lightbox** — cursor classes now gated on the same mode check as the lightbox itself.

Compiled `hooks.js` / `properties.json` were regenerated with `rw-build` in each commit. Remaining lower-priority findings from the audit (dark `<source>` gating, CMS per-breakpoint sources, dead toggle event, `imageFileSize` of 0) were deliberately left out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)