### PR TITLE
Button code-review fixes (BUTTON-CR-001/004/006) + artifact regeneration

### DIFF
--- a/packs/Core.elementsdevpack/components/com.elementsplatform.mask/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.mask/hooks.js
@@ -75,9 +75,17 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -170,7 +178,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.elementsplatform.mask/properties.json
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.mask/properties.json
@@ -1016,7 +1016,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {

--- a/packs/Core.elementsdevpack/components/com.elementsplatform.shapes/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.shapes/hooks.js
@@ -75,9 +75,17 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -170,7 +178,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.elementsplatform.shapes/properties.json
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.shapes/properties.json
@@ -766,7 +766,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {

--- a/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/hooks.js
@@ -87,6 +87,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -156,6 +163,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -164,8 +175,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -174,8 +185,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -183,8 +194,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -194,8 +205,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -342,7 +353,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/properties.json
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/properties.json
@@ -864,7 +864,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -526,8 +540,9 @@ const injectPrefixOnDarkModeColors = (prefix, classes) => {
   return classes.replace(/dark:(.*)/g, `dark:${prefix}:$1`);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -773,6 +788,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -781,8 +800,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -791,8 +810,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -800,8 +819,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -811,8 +830,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -837,7 +856,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
@@ -1000,7 +1000,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1420,6 +1421,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1435,6 +1437,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1450,6 +1453,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1483,6 +1487,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1498,6 +1503,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1513,6 +1519,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1551,6 +1558,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1566,6 +1574,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -442,6 +449,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -492,8 +506,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -720,6 +735,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -728,8 +747,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -738,8 +757,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -747,8 +766,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -758,8 +777,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -784,7 +803,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
@@ -1622,7 +1622,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -2042,6 +2043,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2057,6 +2059,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2072,6 +2075,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2105,6 +2109,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2120,6 +2125,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2135,6 +2141,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2173,6 +2180,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2188,6 +2196,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.background/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.background/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -440,8 +447,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -533,8 +547,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -795,6 +810,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -803,8 +822,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -813,8 +832,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -822,8 +841,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -833,8 +852,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -859,7 +878,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
@@ -973,7 +973,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1393,6 +1394,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1408,6 +1410,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1423,6 +1426,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1456,6 +1460,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1471,6 +1476,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1486,6 +1492,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1524,6 +1531,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1539,6 +1547,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -523,8 +537,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -654,7 +669,7 @@ const globalFilters = (app, args = {}) => {
 const globalLink = (app) => {
   var _a;
   const { globalLink: link = null } = app.props;
-  const hasLink = typeof link === "object" && Object.keys(link).length > 0 && link.href.length > 0;
+  const hasLink = !!link && typeof link === "object" && typeof link.href === "string" && link.href.length > 0;
   let linkAttributes = {
     hasLink,
     args: {}
@@ -770,6 +785,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -778,8 +797,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -788,8 +807,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -797,8 +816,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -808,8 +827,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -834,7 +853,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,
@@ -888,7 +907,7 @@ const transformHook = (rw) => {
     globalBgImageFetchPriorityLinkElementEnd
   } = globalBgImageFetchPriority(rw);
   const { id } = rw.node;
-  const wantsDropzone = dropzoneType != "false";
+  const wantsDropzone = dropzoneType == "left" || dropzoneType == "right";
   const dropzoneSide = dropzoneType == "right" ? "order-last" : "order-first";
   const classes = classnames([
     `group/button group/${id}`,
@@ -897,13 +916,14 @@ const transformHook = (rw) => {
     globalLayout(rw, { defaultDisplay: "flex" }),
     globalSizing(rw),
     globalSpacing(rw),
-    globalTransitions(rw),
+    globalTransitions(rw, true),
     globalEffects(rw),
     globalFilters(rw),
     globalTransforms(rw),
     globalBackground(rw),
     globalBorders(rw),
     globalButtonFontAndTextStylesTextAlign,
+    globalButtonFontAndTextStylesTextAlign.replace(/justify-/g, "text-"),
     globalButtonFontAndTextStylesColor,
     globalButtonFontAndTextStylesColorOpacity,
     globalButtonFontAndTextStylesFont,
@@ -934,7 +954,7 @@ const transformHook = (rw) => {
   rw.setProps({
     dropzoneSide,
     wantsDropzone,
-    showText: showText == "true",
+    showText: showText === true || showText === "true",
     globalBgImageFetchPriorityEnabled,
     globalBgImageFetchPriorityLinkElement,
     globalBgImageFetchPriorityLinkElementEnd

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/hooks.source.js
@@ -31,7 +31,7 @@ const transformHook = (rw) => {
 
     const { id } = rw.node;
 
-    const wantsDropzone = dropzoneType != "false";
+    const wantsDropzone = dropzoneType == "left" || dropzoneType == "right";
     const dropzoneSide = dropzoneType == "right" ? "order-last" : "order-first";
 
     const classes = classnames([
@@ -41,7 +41,7 @@ const transformHook = (rw) => {
         globalLayout(rw, { defaultDisplay: "flex" }),
         globalSizing(rw),
         globalSpacing(rw),
-        globalTransitions(rw),
+        globalTransitions(rw, true),
         globalEffects(rw),
         globalFilters(rw),
         globalTransforms(rw),
@@ -49,6 +49,7 @@ const transformHook = (rw) => {
         globalBorders(rw),
 
         globalButtonFontAndTextStylesTextAlign,
+        globalButtonFontAndTextStylesTextAlign.replace(/justify-/g, "text-"),
 
         globalButtonFontAndTextStylesColor,
         globalButtonFontAndTextStylesColorOpacity,
@@ -84,7 +85,7 @@ const transformHook = (rw) => {
     rw.setProps({
         dropzoneSide,
         wantsDropzone,
-        showText: showText == "true",
+        showText: showText === true || showText === "true",
         globalBgImageFetchPriorityEnabled,
         globalBgImageFetchPriorityLinkElement,
         globalBgImageFetchPriorityLinkElementEnd,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
@@ -1084,7 +1084,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1504,6 +1505,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1519,6 +1521,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1534,6 +1537,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1567,6 +1571,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1582,6 +1587,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1597,6 +1603,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1635,6 +1642,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1650,6 +1658,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -536,8 +550,9 @@ const injectPrefixOnDarkModeColors = (prefix, classes) => {
   return classes.replace(/dark:(.*)/g, `dark:${prefix}:$1`);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -850,7 +865,7 @@ const globalFilter = (rw) => {
 const globalLink = (app) => {
   var _a;
   const { globalLink: link = null } = app.props;
-  const hasLink = typeof link === "object" && Object.keys(link).length > 0 && link.href.length > 0;
+  const hasLink = !!link && typeof link === "object" && typeof link.href === "string" && link.href.length > 0;
   let linkAttributes = {
     hasLink,
     args: {}
@@ -1052,6 +1067,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -1060,8 +1079,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -1070,8 +1089,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -1079,8 +1098,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -1090,8 +1109,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -1116,7 +1135,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -1844,7 +1844,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -2328,6 +2329,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2343,6 +2345,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2358,6 +2361,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2391,6 +2395,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2406,6 +2411,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2421,6 +2427,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2459,6 +2466,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2474,6 +2482,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -480,8 +487,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -521,8 +528,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -507,6 +514,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -557,8 +571,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -793,6 +808,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -801,8 +820,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -811,8 +830,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -820,8 +839,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -831,8 +850,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -857,7 +876,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
@@ -1214,7 +1214,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1634,6 +1635,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1649,6 +1651,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1664,6 +1667,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1697,6 +1701,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1712,6 +1717,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1727,6 +1733,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1765,6 +1772,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1780,6 +1788,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -523,8 +537,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -770,6 +785,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -778,8 +797,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -788,8 +807,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -797,8 +816,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -808,8 +827,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -834,7 +853,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
@@ -1128,7 +1128,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1548,6 +1549,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1563,6 +1565,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1578,6 +1581,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1611,6 +1615,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1626,6 +1631,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1641,6 +1647,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1679,6 +1686,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1694,6 +1702,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -533,8 +547,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -683,7 +698,7 @@ const globalFilter = (rw) => {
 const globalLink = (app) => {
   var _a;
   const { globalLink: link = null } = app.props;
-  const hasLink = typeof link === "object" && Object.keys(link).length > 0 && link.href.length > 0;
+  const hasLink = !!link && typeof link === "object" && typeof link.href === "string" && link.href.length > 0;
   let linkAttributes = {
     hasLink,
     args: {}
@@ -817,6 +832,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -825,8 +844,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -835,8 +854,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -844,8 +863,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -855,8 +874,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -881,7 +900,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -1102,7 +1102,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1522,6 +1523,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1537,6 +1539,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1552,6 +1555,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1585,6 +1589,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1600,6 +1605,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1615,6 +1621,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1653,6 +1660,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1668,6 +1676,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.gallery/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.gallery/hooks.js
@@ -86,8 +86,9 @@ const globalHTMLTag = (app, fallback = "div") => {
   return globalHTMLTag2 || fallback;
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -533,8 +547,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -683,7 +698,7 @@ const globalFilter = (rw) => {
 const globalLink = (app) => {
   var _a;
   const { globalLink: link = null } = app.props;
-  const hasLink = typeof link === "object" && Object.keys(link).length > 0 && link.href.length > 0;
+  const hasLink = !!link && typeof link === "object" && typeof link.href === "string" && link.href.length > 0;
   let linkAttributes = {
     hasLink,
     args: {}
@@ -817,6 +832,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -825,8 +844,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -835,8 +854,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -844,8 +863,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -855,8 +874,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -881,7 +900,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -1277,7 +1277,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1697,6 +1698,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1712,6 +1714,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1727,6 +1730,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1760,6 +1764,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1775,6 +1780,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1790,6 +1796,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1828,6 +1835,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1843,6 +1851,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/hooks.js
@@ -150,6 +150,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -159,8 +166,9 @@ const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId =
   return hoverGroup === "self" ? needsPeerPrefix ? `peer-hover` : "hover" : `group-hover/${hoverGroup}`;
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -290,7 +298,7 @@ const globalFilters = (app, args = {}) => {
 const globalLink = (app) => {
   var _a;
   const { globalLink: link = null } = app.props;
-  const hasLink = typeof link === "object" && Object.keys(link).length > 0 && link.href.length > 0;
+  const hasLink = !!link && typeof link === "object" && typeof link.href === "string" && link.href.length > 0;
   let linkAttributes = {
     hasLink,
     args: {}
@@ -421,6 +429,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -429,8 +441,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -439,8 +451,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -448,8 +460,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -459,8 +471,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -485,7 +497,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
@@ -383,6 +383,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "wantsLightbox == true"
@@ -1199,7 +1200,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1999,6 +2001,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2014,6 +2017,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2029,6 +2033,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2062,6 +2067,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2077,6 +2083,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2092,6 +2099,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2130,6 +2138,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2145,6 +2154,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.list/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.list/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -523,8 +537,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -751,6 +766,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -759,8 +778,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -769,8 +788,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -778,8 +797,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -789,8 +808,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -815,7 +834,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
@@ -1214,7 +1214,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1634,6 +1635,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1649,6 +1651,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1664,6 +1667,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1697,6 +1701,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1712,6 +1717,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1727,6 +1733,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1765,6 +1772,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1780,6 +1788,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -523,8 +537,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -712,6 +727,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -720,8 +739,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -730,8 +749,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -739,8 +758,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -750,8 +769,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -776,7 +795,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
@@ -392,7 +392,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1192,6 +1193,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1207,6 +1209,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1222,6 +1225,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1255,6 +1259,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1270,6 +1275,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1285,6 +1291,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1323,6 +1330,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1338,6 +1346,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.modal/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.modal/properties.json
@@ -227,6 +227,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           }
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -533,8 +547,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -795,6 +810,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -803,8 +822,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -813,8 +832,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -822,8 +841,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -833,8 +852,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -859,7 +878,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
@@ -1097,7 +1097,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1517,6 +1518,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1532,6 +1534,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1547,6 +1550,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1580,6 +1584,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1595,6 +1600,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1610,6 +1616,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1648,6 +1655,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1663,6 +1671,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -442,6 +449,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -492,8 +506,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -720,6 +735,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -728,8 +747,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -738,8 +757,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -747,8 +766,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -758,8 +777,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -784,7 +803,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
@@ -1845,7 +1845,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -2265,6 +2266,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2280,6 +2282,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2295,6 +2298,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2328,6 +2332,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2343,6 +2348,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2358,6 +2364,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2396,6 +2403,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2411,6 +2419,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -533,8 +547,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -854,6 +869,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -862,8 +881,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -872,8 +891,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -881,8 +900,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -892,8 +911,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -1122,7 +1141,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
@@ -2000,7 +2000,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -2420,6 +2421,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2435,6 +2437,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2450,6 +2453,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2483,6 +2487,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2498,6 +2503,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2513,6 +2519,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2551,6 +2558,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2566,6 +2574,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.reveal/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.reveal/hooks.js
@@ -128,8 +128,9 @@ const globalHTMLTag = (app, fallback = "div") => {
   return globalHTMLTag2 || fallback;
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/hooks.js
@@ -87,6 +87,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -96,8 +103,9 @@ const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId =
   return hoverGroup === "self" ? needsPeerPrefix ? `peer-hover` : "hover" : `group-hover/${hoverGroup}`;
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -227,7 +235,7 @@ const globalFilters = (app, args = {}) => {
 const globalLink = (app) => {
   var _a;
   const { globalLink: link = null } = app.props;
-  const hasLink = typeof link === "object" && Object.keys(link).length > 0 && link.href.length > 0;
+  const hasLink = !!link && typeof link === "object" && typeof link.href === "string" && link.href.length > 0;
   let linkAttributes = {
     hasLink,
     args: {}
@@ -343,6 +351,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -351,8 +363,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -361,8 +373,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -370,8 +382,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -381,8 +393,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -407,7 +419,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
@@ -1001,7 +1001,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1801,6 +1802,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1816,6 +1818,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1831,6 +1834,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1864,6 +1868,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1879,6 +1884,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1894,6 +1900,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1932,6 +1939,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1947,6 +1955,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -434,6 +441,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -484,8 +498,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -712,6 +727,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -720,8 +739,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -730,8 +749,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -739,8 +758,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -750,8 +769,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -776,7 +795,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
@@ -2044,7 +2044,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -2464,6 +2465,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2479,6 +2481,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2494,6 +2497,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2527,6 +2531,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2542,6 +2547,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2557,6 +2563,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2595,6 +2602,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2610,6 +2618,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -442,6 +449,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -492,8 +506,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -720,6 +735,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -728,8 +747,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -738,8 +757,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -747,8 +766,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -758,8 +777,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -784,7 +803,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
@@ -2010,7 +2010,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -2430,6 +2431,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2445,6 +2447,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2460,6 +2463,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2493,6 +2497,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2508,6 +2513,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2523,6 +2529,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2561,6 +2568,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2576,6 +2584,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.text/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.text/hooks.js
@@ -154,6 +154,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -181,7 +188,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -189,21 +196,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -211,7 +218,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -219,7 +226,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -410,6 +417,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -463,8 +477,9 @@ const injectPrefixOnDarkModeColors = (prefix, classes) => {
   return classes.replace(/dark:(.*)/g, `dark:${prefix}:$1`);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -691,6 +706,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -699,8 +718,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -709,8 +728,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -718,8 +737,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -729,8 +748,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -755,7 +774,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
@@ -2684,7 +2684,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -3104,6 +3105,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -3119,6 +3121,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -3134,6 +3137,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -3167,6 +3171,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -3182,6 +3187,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -3197,6 +3203,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -3235,6 +3242,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -3250,6 +3258,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/hooks.js
@@ -190,6 +190,13 @@ const globalBgGradient = (app, args) => {
   }
   return classes.toString();
 };
+const encodeBgImageUrl = (url) => String(url).replace(/[ '"()]/g, (char) => ({
+  " ": "%20",
+  "'": "%27",
+  '"': "%22",
+  "(": "%28",
+  ")": "%29"
+})[char]);
 const globalBgImage = (app, args) => {
   const {
     globalControlTypeBg: controlType,
@@ -217,7 +224,7 @@ const globalBgImage = (app, args) => {
   const hasImage = Boolean(resource == null ? void 0 : resource.image);
   const hasImageEnd = Boolean(resourceEnd == null ? void 0 : resourceEnd.image);
   const classes = classnames().add([
-    hasImage ? `bg-[url(${resource.image})]` : "",
+    hasImage ? `bg-[url(${encodeBgImageUrl(resource.image)})]` : "",
     size,
     repeat,
     position
@@ -225,21 +232,21 @@ const globalBgImage = (app, args) => {
   if (controlType == "hover") {
     if (wantsPeer) {
       classes.add([
-        hasImageEnd ? `peer-hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `peer-hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "peer-hover:"),
         repeatEnd.replace(/hover:/g, "peer-hover:"),
         positionEnd.replace(/hover:/g, "peer-hover:")
       ]);
     } else if (hasPrefix) {
       classes.add([
-        hasImageEnd ? prefixCallback(`bg-[url(${resourceEnd.image})]`, args.prefix) : "",
+        hasImageEnd ? prefixCallback(`bg-[url(${encodeBgImageUrl(resourceEnd.image)})]`, args.prefix) : "",
         prefixCallback(sizeEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(repeatEnd.replace(/hover:/g, ""), args.prefix),
         prefixCallback(positionEnd.replace(/hover:/g, ""), args.prefix)
       ]);
     } else {
       classes.add([
-        hasImageEnd ? `hover:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `hover:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd,
         repeatEnd,
         positionEnd
@@ -247,7 +254,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsActive) {
       classes.add([
-        hasImageEnd ? `data-[active=true]:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `data-[active=true]:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "data-[active=true]:"),
         repeatEnd.replace(/hover:/g, "data-[active=true]:"),
         positionEnd.replace(/hover:/g, "data-[active=true]:")
@@ -255,7 +262,7 @@ const globalBgImage = (app, args) => {
     }
     if (wantsFocus) {
       classes.add([
-        hasImageEnd ? `focus:bg-[url(${resourceEnd.image})]` : "",
+        hasImageEnd ? `focus:bg-[url(${encodeBgImageUrl(resourceEnd.image)})]` : "",
         sizeEnd.replace(/hover:/g, "focus:"),
         repeatEnd.replace(/hover:/g, "focus:"),
         positionEnd.replace(/hover:/g, "focus:")
@@ -267,7 +274,7 @@ const globalBgImage = (app, args) => {
 const globalBgVideoThumbnail = (app, args) => {
   const { globalBgVideo: video } = app.props;
   return classnames([
-    `bg-[url(${video == null ? void 0 : video.image})] bg-cover bg-center`
+    `bg-[url(${encodeBgImageUrl(video == null ? void 0 : video.image)})] bg-cover bg-center`
   ]).toString();
 };
 const globalBackground = (app, args = {}) => {
@@ -473,6 +480,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -523,8 +537,9 @@ const resolveGradientImageClass = (type, linearDirection, radialPosition, conicA
   return normalizeGradientImageClass(selectedDirection, interpolation);
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -712,6 +727,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -720,8 +739,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -730,8 +749,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -739,8 +758,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -750,8 +769,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -776,7 +795,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
@@ -392,7 +392,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1192,6 +1193,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1207,6 +1209,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1222,6 +1225,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1255,6 +1259,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1270,6 +1275,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1285,6 +1291,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1323,6 +1330,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1338,6 +1346,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/hooks.js
@@ -150,6 +150,13 @@ const classnames = (initialClasses = "") => {
     }
   };
 };
+const escapeArbitraryWhitespace = (classString) => {
+  if (!classString) return classString;
+  return String(classString).replace(
+    /\[[^\]]*\]/g,
+    (segment) => segment.replace(/\s+/g, "_")
+  );
+};
 const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId = "") => {
   const needsPeerPrefix = node.isContainer && ["background", "content"].includes(applyTo);
   if (hoverGroup === "parent") return `group-hover/${node.parent.id}`;
@@ -159,8 +166,9 @@ const getHoverPrefix = (node = {}, applyTo = "", hoverGroup = "self", customId =
   return hoverGroup === "self" ? needsPeerPrefix ? `peer-hover` : "hover" : `group-hover/${hoverGroup}`;
 };
 const switchToBool = (value) => {
-  if (value === true || value === 1) return true;
-  if (value === false || value === 0) return false;
+  if (value === true || value === false) {
+    return value;
+  }
   if (typeof value === "string") {
     const base = value.trim().split(/\s+/)[0];
     if (base === "true") return true;
@@ -402,6 +410,10 @@ const globalTransforms = (app, args = {}) => {
   const classes = classnames();
   const scaleMirrored = mirrorScaleXToY(scale);
   const scaleEndMirrored = mirrorScaleXToY(scaleEnd);
+  const translateXSafe = escapeArbitraryWhitespace(translateX);
+  const translateYSafe = escapeArbitraryWhitespace(translateY);
+  const translateXEndSafe = escapeArbitraryWhitespace(translateXEnd);
+  const translateYEndSafe = escapeArbitraryWhitespace(translateYEnd);
   if (type != "none") {
     classes.add([
       "transform",
@@ -410,8 +422,8 @@ const globalTransforms = (app, args = {}) => {
       rotate,
       skewX,
       skewY,
-      translateX,
-      translateY
+      translateXSafe,
+      translateYSafe
     ]);
   }
   if (type == "hover") {
@@ -420,8 +432,8 @@ const globalTransforms = (app, args = {}) => {
       addPrefixToTailwindClasses(rotateEnd, prefix),
       addPrefixToTailwindClasses(skewXEnd, prefix),
       addPrefixToTailwindClasses(skewYEnd, prefix),
-      addPrefixToTailwindClasses(translateXEnd, prefix),
-      addPrefixToTailwindClasses(translateYEnd, prefix)
+      addPrefixToTailwindClasses(translateXEndSafe, prefix),
+      addPrefixToTailwindClasses(translateYEndSafe, prefix)
     ]);
     if (wantsActive) {
       classes.add([
@@ -429,8 +441,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewXEnd, "data-[active=true]"),
         addPrefixToTailwindClasses(skewYEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateXEnd, "data-[active=true]"),
-        addPrefixToTailwindClasses(translateYEnd, "data-[active=true]")
+        addPrefixToTailwindClasses(translateXEndSafe, "data-[active=true]"),
+        addPrefixToTailwindClasses(translateYEndSafe, "data-[active=true]")
       ]);
     }
     if (wantsFocus) {
@@ -440,8 +452,8 @@ const globalTransforms = (app, args = {}) => {
         addPrefixToTailwindClasses(rotateEnd, focusPrefix),
         addPrefixToTailwindClasses(skewXEnd, focusPrefix),
         addPrefixToTailwindClasses(skewYEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateXEnd, focusPrefix),
-        addPrefixToTailwindClasses(translateYEnd, focusPrefix)
+        addPrefixToTailwindClasses(translateXEndSafe, focusPrefix),
+        addPrefixToTailwindClasses(translateYEndSafe, focusPrefix)
       ]);
     }
   }
@@ -466,7 +478,7 @@ const globalTransitions = (app, alwaysWantsHover = false) => {
     globalTransitionsTimingFunction: timingFunction,
     globalTransitionsTimingFunctionCustom: customTimingFunction
   } = app.props;
-  const customTimingFunctionFormatted = customTimingFunction == null ? void 0 : customTimingFunction.replace(/,\s/g, ",_");
+  const customTimingFunctionFormatted = escapeArbitraryWhitespace(customTimingFunction);
   const aControlWantsHover = () => {
     return alwaysWantsHover || globalFilterEnable || [
       globalControlTypeTransforms,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
@@ -130,6 +130,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "wantsLightbox == true"
@@ -1098,7 +1099,8 @@
           },
           "format": "duration-[{{value}}ms]",
           "number": {
-            "default": 300
+            "default": 300,
+            "min": 0
           }
         },
         {
@@ -1898,6 +1900,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1913,6 +1916,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1928,6 +1932,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -1961,6 +1966,7 @@
           "format": "blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1976,6 +1982,7 @@
           "format": "brightness-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -1991,6 +1998,7 @@
           "format": "saturate-[{{value}}%]",
           "number": {
             "default": 100,
+            "min": 0,
             "subtitle": "In percent"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"
@@ -2029,6 +2037,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "globalControlTypeFilters == 'static' || (globalControlTypeFilters == 'hover' && globalFiltersState == 'start')"
@@ -2044,6 +2053,7 @@
           "format": "backdrop-blur-[{{value}}px]",
           "number": {
             "default": 0,
+            "min": 0,
             "subtitle": "In pixels"
           },
           "visible": "(globalControlTypeFilters == 'hover' && globalFiltersState == 'end')"


### PR DESCRIPTION
Applies the component-local findings from the RWAI code review of the Button component (`audit/code-review/Core/Button-issues.md`):

- **BUTTON-CR-001** (high) — the root always carries `hover:` text-style classes, but transitions were only emitted when some control type was set to Hover; with Background Static/None a configured hover text colour snapped instantly. Now passes `alwaysWantsHover` to `globalTransitions`, matching accordion/breadcrumbs/navPageList.
- **BUTTON-CR-004** (low) — `showText`/`dropzoneType` comparisons now handle boolean and string delivery (switch value type depends on the `responsive` flag).
- **BUTTON-CR-006** (low) — the Align control only justified the flex row; wrapped label lines stayed left-aligned. A `text-*` class is now derived per breakpoint alongside `justify-*`.

The regeneration commit rebuilds `hooks.js`/`properties.json` (54 files) against the companion Tools branch (BUTTON-CR-002/003/005/007) and also propagates the already-merged `switchToBool` legacy-string support (rw-elements-tools d082e88, PR #15), which had not been recompiled into the committed artifacts.

Verified by running the compiled Button `transformHook` against each finding's cited scenario — 27/27 checks pass (log has details).

Fix-run log: `RWAI/audit/fix/code-review/Fix-Run-2026-08-06.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)