### PR TITLE
Fix Divider width/height defaults and dead classes prop

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/hooks.js
@@ -577,7 +577,6 @@ const transformHook = (rw) => {
     rw.addAnchor(globalID);
   }
   rw.setProps({
-    classes,
     globalBgImageFetchPriorityEnabled,
     globalBgImageFetchPriorityLinkElement,
     globalBgImageFetchPriorityLinkElementEnd

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/hooks.source.js
@@ -31,7 +31,6 @@ const transformHook = (rw) => {
     }
 
     rw.setProps({
-        classes,
         globalBgImageFetchPriorityEnabled,
         globalBgImageFetchPriorityLinkElement,
         globalBgImageFetchPriorityLinkElementEnd,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/properties.config.json
@@ -20,7 +20,10 @@
           "themeSpacing": {
             "mode": "single",
             "default": {
-              "value": "auto"
+              "base": {
+                "custom": false,
+                "value": "auto"
+              }
             }
           }
         },
@@ -31,7 +34,10 @@
           "themeSpacing": {
             "mode": "single",
             "default": {
-              "value": "0.5"
+              "base": {
+                "custom": false,
+                "value": "0.5"
+              }
             }
           }
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/properties.json
@@ -73,7 +73,10 @@
           "themeSpacing": {
             "mode": "single",
             "default": {
-              "value": "auto"
+              "base": {
+                "custom": false,
+                "value": "auto"
+              }
             }
           }
         },
@@ -84,7 +87,10 @@
           "themeSpacing": {
             "mode": "single",
             "default": {
-              "value": "0.5"
+              "base": {
+                "custom": false,
+                "value": "0.5"
+              }
             }
           }
         }


### PR DESCRIPTION
## Findings applied

From [`audit/code-review/Core/Divider-issues.md`](https://github.com/realmacsoftware/RWAI/blob/main/audit/code-review/Core/Divider-issues.md):

- **DIVIDER-CR-001** (high) — `width`/`height` `themeSpacing` defaults used a flat `{"value": ...}` shape instead of the `base`-nested shape every other `themeSpacing` single-mode default in the pack uses, so the default likely never applied on a freshly-placed Divider. Fixed to `default.base.{custom,value}`, matching `Width`/`Height`/`MinWidth`/`MaxWidth`/`MinHeight`/`MaxHeight`.
- **DIVIDER-CR-002** (low) — `classes` was broadcast via `rw.setProps` but never read by any template (the root element already receives it directly via `setRootElement`). Dropped the dead `setProps` key.

DIVIDER-CR-003 is not included — its suggested fix is explicitly "needs discussion" and its only concrete option belongs to a different operation (`rw-ai-block-verification`); left `[open]`.

Rebuilt with `npm run build` (properties + hooks), exit 0. Verified in the built `properties.json`/`hooks.js` that the default now nests under `base` and `classes` no longer appears in the `setProps` call.

Log: `audit/fix/code-review/Fix-Run-2026-08-06.md` (RWAI)