### PR TITLE
FLEX-AIV: regenerate properties + Flex wrap description

### DIFF
--- a/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/properties.json
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/properties.json
@@ -9,7 +9,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
@@ -1590,7 +1590,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
@@ -1028,7 +1028,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
@@ -1301,7 +1301,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
@@ -3256,7 +3256,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.accordion/properties.json
@@ -1970,7 +1970,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
@@ -2592,7 +2592,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
@@ -2212,7 +2212,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
@@ -1650,7 +1650,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
@@ -3878,7 +3878,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.audioPlaylist/properties.json
@@ -1923,7 +1923,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
@@ -1001,7 +1001,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
@@ -1563,7 +1563,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
@@ -3229,7 +3229,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
@@ -1943,7 +1943,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.breadcrumbs/properties.json
@@ -1274,7 +1274,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
@@ -2054,7 +2054,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
@@ -1674,7 +1674,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
@@ -13,7 +13,7 @@
           "id": "globalLink",
           "ai": {
             "name": "link",
-            "description": "Destination this element links to; wraps the element in an anchor. Null clears it."
+            "description": "Destination this element links to; wraps the element in an anchor. Null clears it. Avoid when the element contains other interactive controls."
           },
           "link": {}
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
@@ -3339,7 +3339,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
@@ -1112,7 +1112,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.button/properties.json
@@ -1385,7 +1385,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -1904,7 +1904,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -2209,7 +2209,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -111,7 +111,7 @@
           "id": "globalLink",
           "ai": {
             "name": "link",
-            "description": "Destination this element links to; wraps the element in an anchor. Null clears it."
+            "description": "Destination this element links to; wraps the element in an anchor. Null clears it. Avoid when the element contains other interactive controls."
           },
           "link": {}
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -2906,7 +2906,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -2526,7 +2526,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.container/properties.json
@@ -5547,7 +5547,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/properties.json
@@ -545,7 +545,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.contentSlider/properties.json
@@ -1831,7 +1831,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.divider/properties.json
@@ -1341,7 +1341,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
@@ -3470,7 +3470,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
@@ -1515,7 +1515,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
@@ -1804,7 +1804,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
@@ -1242,7 +1242,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filter/properties.json
@@ -2184,7 +2184,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
@@ -2098,7 +2098,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
@@ -1718,7 +1718,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
@@ -3383,7 +3383,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
@@ -1156,7 +1156,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.filterTags/properties.json
@@ -1429,7 +1429,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.config.json
@@ -36,7 +36,7 @@
         {
           "title": "Wrap Items",
           "id": "wrap",
-          "ai": { "name": "wrap", "description": "Flex item wrapping." },
+          "ai": { "name": "wrap", "description": "Flex wrapping: 'nowrap' keeps one line, 'wrap' adds lines when needed, 'wrap-reverse' wraps additional lines in the opposite cross-axis direction." },
           "format": "flex-{{value}}",
           "select": {
             "default": "nowrap",

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -1403,7 +1403,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -3358,7 +3358,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -140,7 +140,7 @@
           "id": "wrap",
           "ai": {
             "name": "wrap",
-            "description": "Flex item wrapping."
+            "description": "Flex wrapping: 'nowrap' keeps one line, 'wrap' adds lines when needed, 'wrap-reverse' wraps additional lines in the opposite cross-axis direction."
           },
           "format": "flex-{{value}}",
           "select": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -1130,7 +1130,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -2072,7 +2072,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -399,7 +399,7 @@
           "id": "globalLink",
           "ai": {
             "name": "link",
-            "description": "Destination this element links to; wraps the element in an anchor. Null clears it."
+            "description": "Destination this element links to; wraps the element in an anchor. Null clears it. Avoid when the element contains other interactive controls."
           },
           "link": {}
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.flex/properties.json
@@ -1692,7 +1692,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -1578,7 +1578,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -3533,7 +3533,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -1867,7 +1867,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -2247,7 +2247,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -1305,7 +1305,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -573,7 +573,7 @@
           "id": "globalLink",
           "ai": {
             "name": "link",
-            "description": "Destination this element links to; wraps the element in an anchor. Null clears it."
+            "description": "Destination this element links to; wraps the element in an anchor. Null clears it. Avoid when the element contains other interactive controls."
           },
           "link": {}
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
@@ -2170,7 +2170,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
@@ -1501,7 +1501,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
@@ -1228,7 +1228,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
@@ -403,7 +403,7 @@
           "id": "globalLink",
           "ai": {
             "name": "link",
-            "description": "Destination this element links to; wraps the element in an anchor. Null clears it."
+            "description": "Destination this element links to; wraps the element in an anchor. Null clears it. Avoid when the element contains other interactive controls."
           },
           "link": {}
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.image/properties.json
@@ -1881,7 +1881,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
@@ -3470,7 +3470,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
@@ -1515,7 +1515,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
@@ -1804,7 +1804,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
@@ -1242,7 +1242,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.list/properties.json
@@ -2184,7 +2184,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
@@ -693,7 +693,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
@@ -2648,7 +2648,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
@@ -420,7 +420,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
@@ -1073,7 +1073,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.markdown/properties.json
@@ -1362,7 +1362,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
@@ -2067,7 +2067,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
@@ -3353,7 +3353,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
@@ -1125,7 +1125,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
@@ -1398,7 +1398,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
@@ -1687,7 +1687,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
@@ -2146,7 +2146,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
@@ -2435,7 +2435,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
@@ -2815,7 +2815,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
@@ -1873,7 +1873,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navTree/properties.json
@@ -4101,7 +4101,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
@@ -2970,7 +2970,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
@@ -2590,7 +2590,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
@@ -2301,7 +2301,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
@@ -4256,7 +4256,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
@@ -2028,7 +2028,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
@@ -1682,7 +1682,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
@@ -361,7 +361,7 @@
           "id": "globalLink",
           "ai": {
             "name": "link",
-            "description": "Destination this element links to; wraps the element in an anchor. Null clears it."
+            "description": "Destination this element links to; wraps the element in an anchor. Null clears it. Avoid when the element contains other interactive controls."
           },
           "link": {}
         }

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
@@ -1029,7 +1029,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
@@ -1302,7 +1302,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
@@ -2345,7 +2345,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
@@ -4300,7 +4300,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
@@ -2072,7 +2072,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
@@ -3014,7 +3014,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
@@ -2634,7 +2634,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
@@ -2980,7 +2980,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
@@ -4266,7 +4266,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
@@ -2038,7 +2038,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
@@ -2311,7 +2311,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.tabs/properties.json
@@ -2600,7 +2600,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
@@ -2712,7 +2712,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
@@ -2985,7 +2985,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
@@ -3654,7 +3654,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
@@ -3274,7 +3274,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
@@ -693,7 +693,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
@@ -2648,7 +2648,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
@@ -420,7 +420,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
@@ -1073,7 +1073,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.typography/properties.json
@@ -1362,7 +1362,7 @@
           "id": "globalControlTypeBg",
           "ai": {
             "name": "bg",
-            "description": "Enable/disable background."
+            "description": "Background mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
@@ -1400,7 +1400,7 @@
           "id": "globalControlTypeTransforms",
           "ai": {
             "name": "transforms",
-            "description": "Enable/disable transforms."
+            "description": "Transforms mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
@@ -2069,7 +2069,7 @@
           "id": "globalControlTypeBorders",
           "ai": {
             "name": "border",
-            "description": "Enable/disable borders."
+            "description": "Border mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
@@ -1780,7 +1780,7 @@
           "id": "globalControlTypeFilters",
           "ai": {
             "name": "filters",
-            "description": "Enable/disable filters."
+            "description": "Filters mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
@@ -1127,7 +1127,7 @@
           "id": "globalControlTypeEffects",
           "ai": {
             "name": "effects",
-            "description": "Enable/disable effects."
+            "description": "Effects mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {


### PR DESCRIPTION
## Summary
- FLEX-AIV-002…006 / FLEX-AIV-008: regenerate Core `properties.json` after shared-control AI description fixes in RWElementsPacksTools.
- FLEX-AIV-007: author Flex `wrap` description spelling out `nowrap` / `wrap` / `wrap-reverse` semantics.

## Test plan
- [ ] Open Flex inspector AI catalog: ControlType modes and wrap/link descriptions match the finding suggested fixes
- [ ] Smoke other components that embed Effects/Filters/Transforms/Background/Borders/Link

Depends on companion Tools PR on the same branch name.
RWAI fix-run log: `audit/fix/ai-block-verification/Fix-Run-2026-08-06-2.md`

Made with [Cursor](https://cursor.com)