### PR TITLE
GRID-AIV-001: clarify Grid rows AI description

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.config.json
@@ -133,7 +133,7 @@
         {
           "title": "Rows",
           "id": "rows",
-          "ai": { "name": "rows", "description": "Number of grid rows." },
+          "ai": { "name": "rows", "description": "Grid row tracks: 'auto' or a count from 1 to 12." },
           "format": "grid-rows-{{value}}",
           "slider": {
             "default": "auto",

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.grid/properties.json
@@ -219,7 +219,7 @@
           "id": "rows",
           "ai": {
             "name": "rows",
-            "description": "Number of grid rows."
+            "description": "Grid row tracks: 'auto' or a count from 1 to 12."
           },
           "format": "grid-rows-{{value}}",
           "slider": {


### PR DESCRIPTION
## Summary
- **GRID-AIV-001** — Update Grid `rows` AI description so it covers `'auto'` and counts 1–12 (Rule 4).

## Test plan
- [ ] Confirm compiled `properties.json` `rows.ai.description` is `Grid row tracks: 'auto' or a count from 1 to 12.`
- [ ] Spot-check MCP/Assistant catalog for Grid `rows`

RWAI fix-run log: `audit/fix/ai-block-verification/Fix-Run-2026-08-06-4.md`


Made with [Cursor](https://cursor.com)