### PR TITLE
rwai-fix: AI block verification Core batch

### DIFF
--- a/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/properties.json
+++ b/packs/Core.elementsdevpack/components/com.elementsplatform.transforms3d/properties.json
@@ -389,7 +389,7 @@
           "id": "globalControlType3D",
           "ai": {
             "name": "transforms3d",
-            "description": "Enable/disable 3D transforms."
+            "description": "3D transform mode: 'none', 'static', 'hover', or 'mouse' (follow cursor)."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.config.json
@@ -437,7 +437,7 @@
           "id": "globalMenuItemHoverTextShadow",
           "ai": {
             "name": "itemTextShadowHover",
-            "description": "Menu item hover-state text shadow theme token."
+            "description": "Menu item hover/current-page text shadow theme token."
           },
           "format": "hover:{{value}} aria-[current=page]:{{value}}",
           "themeShadow": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navPageList/properties.json
@@ -437,7 +437,7 @@
           "id": "globalMenuItemHoverTextShadow",
           "ai": {
             "name": "itemTextShadowHover",
-            "description": "Menu item hover-state text shadow theme token."
+            "description": "Menu item hover/current-page text shadow theme token."
           },
           "format": "hover:{{value}} aria-[current=page]:{{value}}",
           "themeShadow": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.config.json
@@ -218,7 +218,7 @@
                     "visible": "logoType == 'title'",
                     "title": "Text Shadow",
                     "id": "globalNavTitleTextShadow",
-                    "ai": { "name": "titleTextShadow", "description": "Site title text shadow theme token (title logo only)." },
+                    "ai": { "name": "titleTextShadow", "description": "Site title text shadow theme token." },
                     "themeShadow": {
                         "mode": "text",
                         "default": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.navbar/properties.json
@@ -226,7 +226,7 @@
           "id": "globalNavTitleTextShadow",
           "ai": {
             "name": "titleTextShadow",
-            "description": "Site title text shadow theme token (title logo only)."
+            "description": "Site title text shadow theme token."
           },
           "themeShadow": {
             "mode": "text",

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.config.json
@@ -69,7 +69,7 @@
           "id": "{{value}}SVGFill",
           "ai": {
             "name": "fill",
-            "description": "Enable/disable SVG fill color control."
+            "description": "Fill color mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           }
         },
         {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.config.json
@@ -189,7 +189,7 @@
           "id": "{{value}}SVGStroke",
           "ai": {
             "name": "stroke",
-            "description": "Enable/disable SVG stroke color control."
+            "description": "Stroke color mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           }
         },
         {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
@@ -213,7 +213,7 @@
           "id": "globalControlTypeSVGStroke",
           "ai": {
             "name": "stroke",
-            "description": "Enable/disable SVG stroke color control."
+            "description": "Stroke color mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.svg/properties.json
@@ -69,7 +69,7 @@
           "id": "globalControlTypeSVGFill",
           "ai": {
             "name": "fill",
-            "description": "Enable/disable SVG fill color control."
+            "description": "Fill color mode: 'none' disables, 'static' always applies, 'hover' styles start and hover states separately."
           },
           "responsive": false,
           "segmented": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.config.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.config.json
@@ -962,7 +962,7 @@
           "responsive": false,
           "ai": {
             "name": "rowsPerPage",
-            "description": "Number of rows shown per page when pagination is enabled."
+            "description": "Number of rows shown per page."
           },
           "number": {
             "default": 10,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/properties.json
@@ -1205,7 +1205,7 @@
           "responsive": false,
           "ai": {
             "name": "rowsPerPage",
-            "description": "Number of rows shown per page when pagination is enabled."
+            "description": "Number of rows shown per page."
           },
           "number": {
             "default": 10,

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.text/properties.json
@@ -550,14 +550,7 @@
           "id": "globalHoverGroupBg",
           "ai": {
             "name": "bgHoverTrigger",
-            "description": "Which element's hover triggers the hover text color.",
-            "values": [
-              "self",
-              "parent",
-              "container",
-              "grid",
-              "flex"
-            ]
+            "description": "Which element's hover triggers the hover text color."
           },
           "responsive": false,
           "select": {

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.video/properties.json
@@ -401,7 +401,7 @@
           "id": "objectPosition",
           "ai": {
             "name": "objectPosition",
-            "description": "Focal point of the image within its box when cropped."
+            "description": "Focal point of the video/poster within its box when cropped."
           },
           "select": {
             "default": "object-center",


### PR DESCRIPTION
## Summary
Regenerated / authored `ai` block fixes from AI-block verification reports:

- **VIDEO-AIV-001** — Video objectPosition video/poster wording
- **3DTRANSFORM-AIV-001** — 3D Transform ControlType modes
- **TEXT-AIV-001** — Text bgHoverTrigger full HoverGroup domain
- **MENU-AIV-001** — Menu titleTextShadow drop visibility restatement
- **SVG-AIV-001 / SVG-AIV-002** — SVG fill/stroke ControlType modes
- **TABLE-AIV-001** — Table rowsPerPage drop enable restatement
- **TOPPAGES-AIV-001** — Top Pages itemTextShadowHover includes current-page

Depends on Tools PR for the shared-control edits (VIDEO/3D/TEXT).

RWAI fix-run log: `audit/fix/ai-block-verification/Fix-Run-2026-08-06-5.md`

## Test plan
- [ ] Spot-check compiled AI descriptions for Menu, SVG, Table, Text, Top Pages, Video, 3D Transform
- [ ] Confirm no unrelated `properties.json` churn beyond the listed components

Made with [Cursor](https://cursor.com)