### PR TITLE
Table: fix pagination counter showing raw {{page}}/{{total}} tokens

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.js
@@ -1150,7 +1150,7 @@ const transformHook = (rw) => {
     paginationLastLabel: paginationLastLabel || "Last",
     paginationPageText: pageTextFormat,
     // Pre-substituted variant for the static edit-mode pagination mock
-    paginationPageTextStatic: pageTextFormat.replace("{{page}}", "1").replace("{{total}}", "1"),
+    paginationPageTextStatic: pageTextFormat.replace(/\{\{page\}\}/g, "1").replace(/\{\{total\}\}/g, "1"),
     edit,
     alpineConfig: JSON.stringify(alpineConfig).replace(/"/g, "'"),
     csvColumnMeta: JSON.stringify(csvColumnMeta),

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.source.js
@@ -359,7 +359,7 @@ const transformHook = (rw) => {
         paginationLastLabel: paginationLastLabel || "Last",
         paginationPageText: pageTextFormat,
         // Pre-substituted variant for the static edit-mode pagination mock
-        paginationPageTextStatic: pageTextFormat.replace("{{page}}", "1").replace("{{total}}", "1"),
+        paginationPageTextStatic: pageTextFormat.replace(/\{\{page\}\}/g, "1").replace(/\{\{total\}\}/g, "1"),
         edit,
         alpineConfig: JSON.stringify(alpineConfig).replace(/"/g, "'"),
         csvColumnMeta: JSON.stringify(csvColumnMeta),

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
@@ -147,8 +147,13 @@
             },
 
             pageText() {
-                const fmt = this.$root.dataset.pageText || "Page {{page}} of {{total}}";
-                return fmt.replace("{{page}}", this.page).replace("{{total}}", this.totalPages);
+                // This file is interpolated by the template engine, so the page/total
+                // placeholders must never appear verbatim here — the engine would eat
+                // them. Regex literals keep the braces apart; the fallback builds the
+                // default without placeholders for the same reason.
+                const fmt = this.$root.dataset.pageText;
+                if (!fmt) return "Page " + this.page + " of " + this.totalPages;
+                return fmt.replace(/\{\{page\}\}/g, this.page).replace(/\{\{total\}\}/g, this.totalPages);
             },
         }));
     });

--- a/test/table-component.test.mjs
+++ b/test/table-component.test.mjs
@@ -237,6 +237,27 @@ test("showFirstLast accepts the string form of the switch value", () => {
     assert.equal(rw.computedProps.showFirstLast, true);
 });
 
+test("static page text substitutes every placeholder occurrence", () => {
+    const rw = renderTable({
+        props: {
+            showPagination: true,
+            paginationPageText: "{{page}}/{{total}} — page {{page}}",
+        },
+    });
+
+    assert.equal(rw.computedProps.paginationPageTextStatic, "1/1 — page 1");
+});
+
+test("alpine template contains no template-engine tokens", () => {
+    const alpinePath = "packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html";
+    const source = fs.readFileSync(alpinePath, "utf8");
+
+    assert.ok(
+        !source.includes("{{"),
+        "templates/*.html are interpolated by the Elements template engine, so a literal {{ in alpine.html gets consumed before the JavaScript reaches the browser. Match {{page}}/{{total}} with regex literals like /\\{\\{page\\}\\}/g instead."
+    );
+});
+
 test("new pagination props stay out of the alpine config", () => {
     const rw = renderTable({
         props: { showPagination: true, showFirstLast: true, paginationPageText: "Pagina {{page}} van {{total}}" },


### PR DESCRIPTION
The localizable page-counter format added in 6fd8395 wrote its
{{page}}/{{total}} placeholders verbatim inside templates/alpine.html.
That file is interpolated by the Elements template engine, which consumed
the unknown tokens before the script reached the browser, turning the
substitution into replace("", ...) — which prepends instead of replacing —
so the counter rendered like "73Page {{page}} of {{total}}" in
preview/publish. Edit mode was unaffected because its text is
pre-substituted in hooks.js, which the engine never processes.

Spell the placeholder matches as regex literals (/\{\{page\}\}/g), which
never put two brace characters adjacent so the engine passes them through
untouched, and build the in-template fallback string without placeholders.
The user-facing {{page}}/{{total}} syntax, property defaults, and stored
values are unchanged. The edit-mode static substitution now uses the same
global regexes so repeated tokens behave identically in edit and live.

Adds a regression test asserting alpine.html contains no literal "{{",
plus coverage for repeated placeholder occurrences.

Reported in the Elements 3.0.8 beta forum thread (posts 6 and 12).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ANpdszbqM6zrDv5HuWQUKW