### PR TITLE
Table: fix edit-mode display broken by backslash escapes in alpine.html

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.js
@@ -1150,7 +1150,7 @@ const transformHook = (rw) => {
     paginationLastLabel: paginationLastLabel || "Last",
     paginationPageText: pageTextFormat,
     // Pre-substituted variant for the static edit-mode pagination mock
-    paginationPageTextStatic: pageTextFormat.replace(/\{\{page\}\}/g, "1").replace(/\{\{total\}\}/g, "1"),
+    paginationPageTextStatic: pageTextFormat.split("{{page}}").join("1").split("{{total}}").join("1"),
     edit,
     alpineConfig: JSON.stringify(alpineConfig).replace(/"/g, "'"),
     csvColumnMeta: JSON.stringify(csvColumnMeta),

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.source.js
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/hooks.source.js
@@ -359,7 +359,7 @@ const transformHook = (rw) => {
         paginationLastLabel: paginationLastLabel || "Last",
         paginationPageText: pageTextFormat,
         // Pre-substituted variant for the static edit-mode pagination mock
-        paginationPageTextStatic: pageTextFormat.replace(/\{\{page\}\}/g, "1").replace(/\{\{total\}\}/g, "1"),
+        paginationPageTextStatic: pageTextFormat.split("{{page}}").join("1").split("{{total}}").join("1"),
         edit,
         alpineConfig: JSON.stringify(alpineConfig).replace(/"/g, "'"),
         csvColumnMeta: JSON.stringify(csvColumnMeta),

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
@@ -147,13 +147,13 @@
             },
 
             pageText() {
-                // This file is interpolated by the template engine, so the page/total
-                // placeholders must never appear verbatim here — the engine would eat
-                // them. Regex literals keep the braces apart; the fallback builds the
-                // default without placeholders for the same reason.
-                const fmt = this.$root.dataset.pageText;
-                if (!fmt) return "Page " + this.page + " of " + this.totalPages;
-                return fmt.replace(/\{\{page\}\}/g, this.page).replace(/\{\{total\}\}/g, this.totalPages);
+                // The page/total placeholder tokens must never appear verbatim in
+                // this file (the template engine consumes them), and backslash
+                // escape sequences break the edit-mode renderer — so build the
+                // tokens at runtime instead of writing them literally.
+                const token = (name) => "{" + "{" + name + "}" + "}";
+                const fmt = this.$root.dataset.pageText || "Page " + token("page") + " of " + token("total");
+                return fmt.split(token("page")).join(this.page).split(token("total")).join(this.totalPages);
             },
         }));
     });

--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
@@ -1,4 +1,5 @@
 @portal(bodyEnd, id: "com.realmacsoftware.table.alpine", includeOnce: true)
+@raw()
 <script>
     document.addEventListener("alpine:init", () => {
         Alpine.data("elementsTable", (id, config) => ({
@@ -147,15 +148,11 @@
             },
 
             pageText() {
-                // The page/total placeholder tokens must never appear verbatim in
-                // this file (the template engine consumes them), and backslash
-                // escape sequences break the edit-mode renderer — so build the
-                // tokens at runtime instead of writing them literally.
-                const token = (name) => "{" + "{" + name + "}" + "}";
-                const fmt = this.$root.dataset.pageText || "Page " + token("page") + " of " + token("total");
-                return fmt.split(token("page")).join(this.page).split(token("total")).join(this.totalPages);
+                const fmt = this.$root.dataset.pageText || "Page {{page}} of {{total}}";
+                return fmt.split("{{page}}").join(this.page).split("{{total}}").join(this.totalPages);
             },
         }));
     });
 </script>
+@endraw
 @endportal

--- a/test/table-component.test.mjs
+++ b/test/table-component.test.mjs
@@ -248,13 +248,14 @@ test("static page text substitutes every placeholder occurrence", () => {
     assert.equal(rw.computedProps.paginationPageTextStatic, "1/1 — page 1");
 });
 
-test("alpine template contains no template-engine tokens", () => {
+test("alpine template contains no template-engine tokens outside @raw blocks", () => {
     const alpinePath = "packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html";
     const source = fs.readFileSync(alpinePath, "utf8");
+    const outsideRaw = source.replace(/@raw\(\)[\s\S]*?@endraw/g, "");
 
     assert.ok(
-        !source.includes("{{"),
-        "templates/*.html are interpolated by the Elements template engine, so a literal {{ in alpine.html gets consumed before the JavaScript reaches the browser. Build the token at runtime instead, e.g. \"{\" + \"{\" + name + \"}\" + \"}\"."
+        !outsideRaw.includes("{{"),
+        "templates/*.html are interpolated by the Elements template engine, so a literal {{ in alpine.html gets consumed before the JavaScript reaches the browser. Wrap script content that needs literal braces in @raw() ... @endraw."
     );
 });
 

--- a/test/table-component.test.mjs
+++ b/test/table-component.test.mjs
@@ -254,7 +254,17 @@ test("alpine template contains no template-engine tokens", () => {
 
     assert.ok(
         !source.includes("{{"),
-        "templates/*.html are interpolated by the Elements template engine, so a literal {{ in alpine.html gets consumed before the JavaScript reaches the browser. Match {{page}}/{{total}} with regex literals like /\\{\\{page\\}\\}/g instead."
+        "templates/*.html are interpolated by the Elements template engine, so a literal {{ in alpine.html gets consumed before the JavaScript reaches the browser. Build the token at runtime instead, e.g. \"{\" + \"{\" + name + \"}\" + \"}\"."
+    );
+});
+
+test("alpine template contains no backslashes", () => {
+    const alpinePath = "packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html";
+    const source = fs.readFileSync(alpinePath, "utf8");
+
+    assert.ok(
+        !source.includes("\\"),
+        "Backslash escape sequences in templates/*.html break the Elements edit-mode renderer (the 3.0.8 regex-literal regression). Avoid regexes and string escapes here — build special strings at runtime by concatenation instead."
     );
 });
 


### PR DESCRIPTION
## What changed

Follow-up to #115 / 1e45f20. That fix stopped the pagination counter showing raw `{{page}}`/`{{total}}` tokens in preview, but its regex-literal escaping (`/\{\{page\}\}/g`) broke the Table's display in **edit mode**.

- `templates/alpine.html` — the script is now wrapped in `@raw()` ... `@endraw`, the documented directive for content the template engine must pass through verbatim. `pageText()` reads naturally again with literal `{{page}}`/`{{total}}` strings, substituted via `split`/`join` (replace-all semantics, no regex escapes).
- `hooks.source.js` / `hooks.js` — the pre-substituted edit-mode counter swaps the regexes for `split("{{page}}").join("1")`. Literal brace strings are proven safe in hooks (they predate 3.0.8), and hooks are never template-processed.
- `test/table-component.test.mjs` — the no-`{{` guard now exempts `@raw()` blocks, plus a new regression test asserting alpine.html contains **no backslashes at all**.

## Why

The edit-mode canvas renderer is a different pipeline stage from preview/publish's PHP path, and it chokes on backslash escape sequences. The escaped-brace approach was verified inert through the other stages — the template was run through the app's own `elementsLangTranspiler.js` and its bundled Handlebars 4.7.7, both of which pass it through verbatim — and the emitted JS is valid, so the backslashes (zero in the file before 1e45f20, eight after) are what broke edit mode.

`@raw()` removes both failure modes idiomatically: the engine never consumes the placeholder tokens (the original preview bug), and the file contains no backslashes (the edit-mode regression). Since CMS placeholders rely on `@raw` output surviving every stage, this is the supported path rather than a workaround.

## Reviewer notes

- All 22 table tests pass (`node --test test/table-component.test.mjs`).
- Verified against the shipped transpiler: `@raw()` nests inside `@portal` (portal id/includeOnce args still processed), and the script emits as a single verbatim text segment with no consumed tokens. Note the grammar requires the parens — bare `@raw` is a syntax error.
- The forum-reported preview bug (3.0.8 beta thread, posts 6 and 12) stays fixed.
- Not included: `rw-build hooks` currently regenerates all 30 components with unrelated shared-hooks drift from RWElementsPacksTools (a newer `switchToBool`). That mass rebuild was reverted here to keep this fix minimal; the table's `hooks.js` was synced surgically. The drift should land in its own rebuild commit.
- One caveat: verified against the engine stages extractable from the app bundle, not visually inside Elements — please reload the dev pack and confirm the table renders in edit mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)