### PR TITLE
Table: revert @raw() change that blanked the component in Elements

### DIFF
--- a/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
+++ b/packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html
@@ -1,5 +1,4 @@
 @portal(bodyEnd, id: "com.realmacsoftware.table.alpine", includeOnce: true)
-@raw()
 <script>
     document.addEventListener("alpine:init", () => {
         Alpine.data("elementsTable", (id, config) => ({
@@ -148,11 +147,19 @@
             },
 
             pageText() {
-                const fmt = this.$root.dataset.pageText || "Page {{page}} of {{total}}";
-                return fmt.split("{{page}}").join(this.page).split("{{total}}").join(this.totalPages);
+                // The page/total placeholder tokens must never appear verbatim in
+                // this file (the template engine consumes them), backslash escape
+                // sequences break the edit-mode renderer, and the raw directive is
+                // no escape hatch either: it parses fine but the literal brace
+                // tokens it preserves kill the edit-mode canvas, blanking the
+                // whole table (see the 8e5dafa revert). Runtime token construction
+                // is the only formulation every pipeline stage tolerates — do not
+                // "clean up". Even comments here are lexed for directives/tokens.
+                const token = (name) => "{" + "{" + name + "}" + "}";
+                const fmt = this.$root.dataset.pageText || "Page " + token("page") + " of " + token("total");
+                return fmt.split(token("page")).join(this.page).split(token("total")).join(this.totalPages);
             },
         }));
     });
 </script>
-@endraw
 @endportal

--- a/test/table-component.test.mjs
+++ b/test/table-component.test.mjs
@@ -248,14 +248,23 @@ test("static page text substitutes every placeholder occurrence", () => {
     assert.equal(rw.computedProps.paginationPageTextStatic, "1/1 — page 1");
 });
 
-test("alpine template contains no template-engine tokens outside @raw blocks", () => {
+test("alpine template contains no template-engine tokens", () => {
     const alpinePath = "packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html";
     const source = fs.readFileSync(alpinePath, "utf8");
-    const outsideRaw = source.replace(/@raw\(\)[\s\S]*?@endraw/g, "");
 
     assert.ok(
-        !outsideRaw.includes("{{"),
-        "templates/*.html are interpolated by the Elements template engine, so a literal {{ in alpine.html gets consumed before the JavaScript reaches the browser. Wrap script content that needs literal braces in @raw() ... @endraw."
+        !source.includes("{{"),
+        "templates/*.html are interpolated by the Elements template engine, so a literal {{ in alpine.html gets consumed before the JavaScript reaches the browser. Build the token at runtime instead, e.g. \"{\" + \"{\" + name + \"}\" + \"}\"."
+    );
+});
+
+test("alpine template contains no @raw blocks", () => {
+    const alpinePath = "packs/Core.elementsdevpack/components/com.realmacsoftware.table/templates/alpine.html";
+    const source = fs.readFileSync(alpinePath, "utf8");
+
+    assert.ok(
+        !source.includes("@raw"),
+        "@raw() parses cleanly in the transpiler but the literal {{...}} text it preserves breaks the Elements edit-mode canvas renderer, blanking the entire component (the 8e5dafa regression). Build brace tokens at runtime by concatenation instead."
     );
 });
 


### PR DESCRIPTION
## What changed

Reverts 8e5dafa (the `@raw()` rewrite of the pagination script) and restores the runtime token-concatenation approach from 214f7b2 in `templates/alpine.html` — no literal braces, no backslashes, no `@raw`. Also restores the strict "no `{{` anywhere" regression test and adds a new guard banning `@raw` in this file.

## Why

After 8e5dafa the Table component rendered **nothing at all** in the Elements app — Collection, CSV file, and remote CSV modes alike.

The `@raw()` directive isn't the parse failure you'd expect — running the app's own `elementsLangTranspiler.js` against the template confirms it parses cleanly and preserves the literal `{{page}}`/`{{total}}` tokens exactly as documented. That preservation is the bug: those brace tokens reached the edit-mode canvas renderer for the first time, and that separate, stricter pipeline stage (the same one the backslash escapes broke) dies on them. Since `alpine.html` is included unconditionally on line 1 of `index.php`, the whole component blanked.

The token-concatenation formulation is the only one every pipeline stage tolerates, and it keeps the original pagination-counter fix (1e45f20) intact: the user-facing `{{page}}`/`{{total}}` format strings travel as property data, and the JS builds the match tokens at runtime.

## Notes for review

- The in-template warning comment now documents all three known-fatal escaping traps. While rewording it, the transpiler harness caught a fourth gotcha: the lexer scans JS **comments** inside templates too — writing `@raw()` or `{{` in a comment is itself a syntax error. The comment says so.
- All 23 component tests pass; both templates parse cleanly through the app's actual transpiler with zero `{{` in the output.
- Please verify in the Elements app before merging (edit mode in all three data-source modes, plus the preview pagination counter showing "Page 1 of N"). Lesson from this regression: a passing transpiler parse is necessary but not sufficient.
- Durable follow-up (separate PR): move the portal script out of the template into a shared asset so template-engine escaping rules stop applying to JavaScript entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)